### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/renderers/MarkdownRenderer.ts
+++ b/src/renderers/MarkdownRenderer.ts
@@ -2,7 +2,7 @@ import type { AuditResult } from '../findings/AuditResult.js';
 import type { AuditRenderer } from './AuditRenderer.js';
 
 function escapeMdCell(s: string): string {
-  return s.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  return s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
 export class MarkdownRenderer implements AuditRenderer {


### PR DESCRIPTION
Potential fix for [https://github.com/cclabsnz/sf-audit-plugin/security/code-scanning/1](https://github.com/cclabsnz/sf-audit-plugin/security/code-scanning/1)

In general, when escaping characters by prefixing them with backslashes, you must first escape any existing backslashes; otherwise, sequences like `\|` will become `\\|` and may be interpreted differently than intended. The robust pattern is: first replace `\` with `\\` globally, then escape other meta-characters (here, `|`), then do any non-escaping transformations like replacing newlines.

For this specific code, the best fix is to update `escapeMdCell` so that it first escapes all backslashes, then escapes all pipe characters, and finally replaces newlines with spaces as before. This preserves functionality (pipes are still escaped; newlines still become spaces) while ensuring that newly added backslashes do not interact incorrectly with pre-existing ones. The change is confined to `escapeMdCell` in `src/renderers/MarkdownRenderer.ts`, line 5. No new imports or helpers are required; a single extra `.replace` call using a global regex for backslashes suffices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
