### PR TITLE
fix(events): stream large EventLogFile downloads to disk

### DIFF
--- a/src/api/RestClient.ts
+++ b/src/api/RestClient.ts
@@ -3,5 +3,10 @@ export interface RestClient {
   get<T>(path: string): Promise<T>;
   // Like get, but returns the response body verbatim as a string. Use for endpoints that
   // return non-JSON payloads — e.g. EventLogFile's /LogFile, which returns text/csv.
+  // NOTE: buffers the whole body in memory; do not use for large LogFiles (see getRawToFile).
   getRaw(path: string): Promise<string>;
+  // Stream a non-JSON body straight to a file, never holding it in memory. Required for large
+  // EventLogFile LogFiles (a busy org's daily Sites/URI logs can be hundreds of MB and exceed
+  // the max JS string length). Returns the number of bytes written.
+  getRawToFile(path: string, destPath: string): Promise<number>;
 }

--- a/src/api/RestClientImpl.ts
+++ b/src/api/RestClientImpl.ts
@@ -1,3 +1,9 @@
+import { createWriteStream } from 'node:fs';
+import { mkdir, rm, stat } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import type { Connection } from '@salesforce/core';
 import type { RestClient } from './RestClient.js';
 
@@ -15,5 +21,27 @@ export class RestClientImpl implements RestClient {
     const normalised = path.startsWith('/') ? path : `/${path}`;
     // jsforce returns the raw body string for non-JSON content types (text/csv here).
     return this.conn.request<string>(`/services/data/v${version}${normalised}`);
+  }
+
+  async getRawToFile(path: string, destPath: string): Promise<number> {
+    const version = this.conn.getApiVersion();
+    const normalised = path.startsWith('/') ? path : `/${path}`;
+    // Stream directly from the org to disk with the session bearer token, so the body is never
+    // materialised as a JS string (which would fail on logs larger than ~512 MB).
+    const url = `${this.conn.instanceUrl}/services/data/v${version}${normalised}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.conn.accessToken ?? ''}` },
+    });
+    if (!res.ok || !res.body) {
+      throw new Error(`Download failed for ${normalised} (HTTP ${res.status})`);
+    }
+    await mkdir(dirname(destPath), { recursive: true });
+    try {
+      await pipeline(Readable.fromWeb(res.body as WebReadableStream<Uint8Array>), createWriteStream(destPath));
+    } catch (err) {
+      await rm(destPath, { force: true }); // never leave a partial file behind
+      throw err;
+    }
+    return (await stat(destPath)).size;
   }
 }

--- a/src/events/pullEventLogs.ts
+++ b/src/events/pullEventLogs.ts
@@ -104,9 +104,9 @@ export async function pullEventLogs(deps: PullDeps, opts: PullOptions): Promise<
     }
 
     try {
-      const body = await rest.getRaw(`/sobjects/EventLogFile/${row.Id}/LogFile`);
-      const savedPath = store.save(orgId, row.EventType, logDate, row.Id, body);
-      const bytes = Buffer.byteLength(body, 'utf-8');
+      // Stream straight to disk — never buffer the body — so large daily logs don't blow the heap.
+      const savedPath = store.pathFor(orgId, row.EventType, logDate, row.Id);
+      const bytes = await rest.getRawToFile(`/sobjects/EventLogFile/${row.Id}/LogFile`, savedPath);
       base.downloaded += 1;
       base.totalBytes += bytes;
       base.logs.push({ id: row.Id, eventType: row.EventType, logDate, bytes, savedPath, status: 'downloaded' });

--- a/test/unit/api/RestClientImpl.test.ts
+++ b/test/unit/api/RestClientImpl.test.ts
@@ -1,3 +1,7 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Readable } from 'node:stream';
 import { jest } from '@jest/globals';
 import { RestClientImpl } from '../../../src/api/RestClientImpl.js';
 
@@ -54,6 +58,45 @@ describe('RestClientImpl', () => {
       fakeConn.request.mockResolvedValue(csv);
       const result = await client.getRaw('/sobjects/EventLogFile/ID/LogFile');
       expect(result).toBe(csv);
+    });
+  });
+
+  describe('getRawToFile', () => {
+    let tmp: string;
+    const origFetch = global.fetch;
+
+    beforeEach(() => {
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rest-getrawtofile-'));
+      fakeConn.instanceUrl = 'https://example.my.salesforce.com';
+      fakeConn.accessToken = 'TOKEN123';
+    });
+
+    afterEach(() => {
+      global.fetch = origFetch;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('streams the body to disk (creating parent dirs) and returns the byte count', async () => {
+      const csv = 'EVENT_TYPE,TIMESTAMP\nLogin,20260707T101500.000Z\n';
+      const body = Readable.toWeb(Readable.from([Buffer.from(csv)]));
+      global.fetch = jest.fn(async () => ({ ok: true, status: 200, body })) as any;
+
+      const dest = path.join(tmp, 'Sites', 'out.csv'); // nested dir does not exist yet
+      const bytes = await client.getRawToFile('/sobjects/EventLogFile/ID/LogFile', dest);
+
+      expect(fs.readFileSync(dest, 'utf-8')).toBe(csv);
+      expect(bytes).toBe(Buffer.byteLength(csv, 'utf-8'));
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.my.salesforce.com/services/data/v62.0/sobjects/EventLogFile/ID/LogFile',
+        { headers: { Authorization: 'Bearer TOKEN123' } }
+      );
+    });
+
+    it('throws and leaves no file on a non-2xx response', async () => {
+      global.fetch = jest.fn(async () => ({ ok: false, status: 404, body: null })) as any;
+      const dest = path.join(tmp, 'out.csv');
+      await expect(client.getRawToFile('/x/LogFile', dest)).rejects.toThrow();
+      expect(fs.existsSync(dest)).toBe(false);
     });
   });
 });

--- a/test/unit/commands/events-pull.test.ts
+++ b/test/unit/commands/events-pull.test.ts
@@ -74,11 +74,15 @@ describe('pullEventLogs', () => {
   });
 
   function restReturning(map: Record<string, string>) {
-    const getRaw = jest.fn(async (p: any) => {
+    // Mirrors RestClientImpl.getRawToFile: streams the body to destPath and returns byte count.
+    const getRawToFile = jest.fn(async (p: any, dest: any) => {
       const id = String(p).split('/')[3]; // /sobjects/EventLogFile/{id}/LogFile
-      return map[id] ?? '';
+      const body = map[id] ?? '';
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, body, 'utf-8');
+      return Buffer.byteLength(body, 'utf-8');
     });
-    return { getRaw } as any;
+    return { getRawToFile } as any;
   }
 
   it('downloads every row, saves CSV verbatim, and returns a summary + manifest', async () => {
@@ -96,7 +100,7 @@ describe('pullEventLogs', () => {
 
     const loginFile = path.join(tmpDir, ORG, 'Login', '2026-07-07-0AT0001.csv');
     expect(fs.readFileSync(loginFile, 'utf-8')).toBe(CSV_A);
-    expect(rest.getRaw).toHaveBeenCalledWith('/sobjects/EventLogFile/0AT0001/LogFile');
+    expect(rest.getRawToFile).toHaveBeenCalledWith('/sobjects/EventLogFile/0AT0001/LogFile', loginFile);
   });
 
   it('skips rows already on disk and does not re-download them (dedup / idempotency)', async () => {
@@ -104,13 +108,13 @@ describe('pullEventLogs', () => {
     const rest = restReturning({ '0AT0001': CSV_A, '0AT0002': CSV_B });
 
     await pullEventLogs({ soql, rest, store, orgId: ORG }, { since: 1 });
-    rest.getRaw.mockClear();
+    rest.getRawToFile.mockClear();
 
     const second = await pullEventLogs({ soql, rest, store, orgId: ORG }, { since: 1 });
     expect(second.found).toBe(2);
     expect(second.skipped).toBe(2);
     expect(second.downloaded).toBe(0);
-    expect(rest.getRaw).not.toHaveBeenCalled();
+    expect(rest.getRawToFile).not.toHaveBeenCalled();
   });
 
   it('returns found: 0 with no download attempts for an empty result set (no throw)', async () => {
@@ -121,7 +125,7 @@ describe('pullEventLogs', () => {
     expect(result.found).toBe(0);
     expect(result.downloaded).toBe(0);
     expect(result.manifestPath).toBeUndefined();
-    expect(rest.getRaw).not.toHaveBeenCalled();
+    expect(rest.getRawToFile).not.toHaveBeenCalled();
   });
 
   it('classifies a permission failure instead of throwing', async () => {
@@ -135,6 +139,6 @@ describe('pullEventLogs', () => {
     const result = await pullEventLogs({ soql, rest, store, orgId: ORG }, { since: 1 });
     expect(result.found).toBe(0);
     expect(result.accessError).toBe('no-permission');
-    expect(rest.getRaw).not.toHaveBeenCalled();
+    expect(rest.getRawToFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem
`getRaw()` returned the whole EventLogFile `/LogFile` body as a JS **string**, which `pullEventLogs` then wrote with `writeFileSync`. A busy org's daily `Sites`/`URI`/`AuraRequest` logs can be **hundreds of MB** — past Node's ~512 MB max string length — so those downloads **failed silently** and the most important logs were dropped.

## Fix
- Add `RestClient.getRawToFile(path, destPath): Promise<number>` — streams the response body from the org straight to disk with the session bearer token via a Node `stream/promises` pipeline, **never** holding it in memory. Cleans up a partial file on error; returns bytes written.
- Switch `pullEventLogs` to `getRawToFile` (writes to `store.pathFor(...)`).
- `getRaw` stays for small non-JSON bodies.

## Tests
- `getRawToFile`: streams to disk (creating parent dirs) + returns byte count; throws and leaves no file on a non-2xx response.
- `pullEventLogs` mock updated to the streaming contract.
- Full suite: **404 passing**.

## Why now
Makes `sf audit events pull` reliable for large logs — the collection half of the `events pull → sfelf-triage analyze` triage workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)