### PR TITLE
chore(release): 1.6.1 — security fix + provenance/SBOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cclabsnz/sf-audit",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Salesforce Security Audit — native sf plugin",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
First release cut through the new hardened pipeline.

## What ships to npm users
- **fix(deps):** brace-expansion pinned to `5.0.8` — resolves high-severity DoS advisory [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) reaching prod via `@oclif/core`.
- **Build provenance (OIDC)** — signed attestation linking the published tarball to this commit; no long-lived npm token.
- **CycloneDX SBOM** attached to the GitHub Release.

## Repo-level assurance (already on main)
- Read-only invariant guard (CI fails on any org-write path), CodeQL, OpenSSF Scorecard, `pnpm audit` gate, SHA-pinned actions.

No changes to the plugin's checks or CLI surface — version bump + dependency/security only.

Publishing is automated: merging this and cutting the `v1.6.1` GitHub Release triggers `publish.yml`.