### PR TITLE
fix(ci): enable npm OIDC trusted publishing (drop registry-url)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,12 @@ jobs:
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
+      # NOTE: no `registry-url` — it makes setup-node write an .npmrc with a
+      # placeholder _authToken, which blocks npm's OIDC trusted-publishing exchange
+      # (results in E404 on publish). Omitting it lets `npm publish` do the OIDC flow.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
           cache: pnpm
 
       - name: Install (frozen lockfile)


### PR DESCRIPTION
The v1.6.1 publish failed with E404: setup-node's `registry-url` writes an .npmrc with a placeholder `_authToken`, which blocks npm's OIDC trusted-publishing exchange. Removing it lets `npm publish --provenance` do the OIDC flow. Provenance signing already worked; only registry auth was broken.