### PR TITLE
chore(ci): publish version diagnostics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,16 @@ jobs:
         run: pnpm test
 
       # Trusted Publishing (OIDC) needs a recent npm CLI (>= 11.5.1).
-      - name: Upgrade npm
-        run: npm install -g npm@latest
+      - name: Upgrade npm (>= 11.5.1 required for OIDC trusted publishing)
+        run: |
+          npm install -g npm@latest
+          echo "node: $(node -v)"
+          echo "npm:  $(npm -v)  (path: $(which npm))"
 
       - name: Publish to npm with provenance (OIDC trusted publishing)
-        run: npm publish --provenance --access public
+        run: |
+          node -v && npm -v
+          npm publish --provenance --access public
 
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0


### PR DESCRIPTION
Adds node/npm version output to the publish step to diagnose the OIDC `ENEEDAUTH` (need to confirm npm >= 11.5.1 is on PATH).