### PR TITLE
ci(codeql): scan Actions workflows (close stale permissions alert)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        language: [javascript-typescript]
+        # `actions` scans the workflow files themselves (token perms, unpinned deps, ...).
+        language: [javascript-typescript, actions]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL


### PR DESCRIPTION
Adds `actions` to the CodeQL language matrix so workflow files are scanned again (this coverage came from the default setup I disabled in favour of the advanced `security-extended` workflow). Resolves the lingering `actions/missing-workflow-permissions` alert, which is already fixed in-file (guard workflow has `permissions: contents: read`) but couldn't auto-close without an actions scan.