### PR TITLE
ci: Semgrep SAST + dependency license policy (regulated-env readiness)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,8 @@ jobs:
       - uses: actions/dependency-review-action@cc4f6536e38d1126c5e3b0683d469a14f23bfea4 # v3
         with:
           fail-on-severity: high
+          # License policy (regulated-environment readiness): block newly-introduced
+          # dependencies under strong-copyleft licenses that are problematic to
+          # redistribute in a permissively-licensed (Apache-2.0) CLI. Applies to
+          # PR-added deps only; tune the list as needed.
+          deny-licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,42 @@
+name: Semgrep
+
+# Second static-analysis lens alongside CodeQL. Runs the public Semgrep rulesets
+# (no account/token needed) and uploads findings to the Security tab as code-scanning
+# alerts. Non-blocking by design — it informs review rather than hard-failing PRs, the
+# same posture as CodeQL alerts. Actions pinned to commit SHAs.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '41 6 * * 1' # Mondays 06:41 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Semgrep
+        run: pipx install semgrep # pipx is preinstalled on GitHub-hosted runners
+
+      - name: Scan (public rulesets)
+        run: |
+          semgrep scan \
+            --config p/default \
+            --config p/typescript \
+            --config p/security-audit \
+            --config p/owasp-top-ten \
+            --sarif --output semgrep.sarif || true
+
+      - name: Upload findings to code scanning
+        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/codeql.yml/badge.svg)](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/codeql.yml)
+[![Semgrep](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/semgrep.yml/badge.svg)](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/semgrep.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/cclabsnz/sf-audit-plugin/badge)](https://securityscorecards.dev/viewer/?uri=github.com/cclabsnz/sf-audit-plugin)
 [![npm version](https://img.shields.io/npm/v/@cclabsnz/sf-audit)](https://www.npmjs.com/package/@cclabsnz/sf-audit)
 [![npm provenance](https://img.shields.io/badge/npm-signed%20provenance-brightgreen)](https://www.npmjs.com/package/@cclabsnz/sf-audit#provenance)
@@ -312,7 +313,8 @@ Because this tool authenticates against production orgs, "is it safe to run?" de
   npm audit signatures   # reports "verified attestations" for @cclabsnz/sf-audit
   ```
 
-- **Independent scans on every change.** [CodeQL](https://github.com/cclabsnz/sf-audit-plugin/security/code-scanning) static analysis (of both the source **and** the CI workflows), an [OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/cclabsnz/sf-audit-plugin) supply-chain review, a PR **dependency-review** gate, and a `pnpm audit` gate (fails on known high-severity advisories) — plus Dependabot for updates. All GitHub Actions are pinned to commit SHAs. Each release ships a CycloneDX **SBOM**.
+- **Independent scans on every change.** Two static-analysis engines — [CodeQL](https://github.com/cclabsnz/sf-audit-plugin/security/code-scanning) (`security-extended`, of both the source **and** the CI workflows) and [Semgrep](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/semgrep.yml) (OWASP Top 10 + security-audit rulesets) — an [OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/cclabsnz/sf-audit-plugin) supply-chain review, a PR **dependency-review** gate (vulnerabilities **and** a copyleft-license policy), and a `pnpm audit` gate — plus Dependabot, and GitHub secret scanning with push protection. All GitHub Actions are pinned to commit SHAs. Each release ships a CycloneDX **SBOM**.
+- **Regulated-environment readiness.** The above give reviewers a paper trail for procurement: SBOM per release, an enforced dependency **license policy**, signed provenance, and independent SAST/supply-chain scans.
 - **Least privilege & disclosure.** See [PERMISSIONS.md](PERMISSIONS.md) for the minimal access it needs and [SECURITY.md](SECURITY.md) for private vulnerability reporting.
 
 ## Scoring


### PR DESCRIPTION
Adds the two scanners discussed, oriented toward regulated-environment approval:

- **Semgrep** (`semgrep.yml`) — second SAST engine, public OWASP Top 10 + security-audit rulesets (no account/token), findings upload to the Security tab as code-scanning alerts. Non-blocking, SHA-pinned.
- **Dependency license policy** — `dependency-review` now blocks PR-introduced deps under strong-copyleft (AGPL/GPL) licenses, complementing the per-release SBOM so licensing can't drift.
- README: Semgrep badge + Trust/regulated-readiness notes.

**Socket.dev** (malicious-dependency detection) is a 1-click GitHub App install — no code — see PR discussion / next step.