### PR TITLE
docs: CloudCounsel logo in README header + og image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <a href="https://cloudcounsel.co.nz"><img src="assets/cloudcounsel-icon.svg" width="56" height="56" alt="CloudCounsel" /></a>
+</p>
+
 # @cclabsnz/sf-audit
 
 [![CI](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/ci.yml)

--- a/assets/cloudcounsel-icon.svg
+++ b/assets/cloudcounsel-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='13' fill='none' stroke='#1a1d24' stroke-width='1' opacity='.4'/><path d='M20.9 12.6 A6 6 0 1 0 20.9 19.4' fill='none' stroke='#1a1d24' stroke-width='5' stroke-linecap='round'/><circle cx='16' cy='16' r='1.5' fill='#3a5a82'/></svg>

--- a/assets/cloudcounsel-og.svg
+++ b/assets/cloudcounsel-og.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="CloudCounsel — Salesforce Platform Architecture, Auckland NZ">
+
+  <!-- Background: slate paper -->
+  <rect width="1200" height="630" fill="#e9e9e3"/>
+
+  <!-- Subtle top and bottom rule to frame the card -->
+  <line x1="0" y1="0" x2="1200" y2="0" stroke="#1a1d24" stroke-opacity="0.18" stroke-width="3"/>
+  <line x1="0" y1="627" x2="1200" y2="627" stroke="#1a1d24" stroke-opacity="0.18" stroke-width="3"/>
+
+  <!-- Watermark: large faint logo mark, right side background -->
+  <g transform="translate(750, 63) scale(7.5)" opacity="0.04">
+    <circle cx="16" cy="16" r="13" fill="none" stroke="#1a1d24" stroke-width="1"/>
+    <path d="M20.9 12.6 A6 6 0 1 0 20.9 19.4" fill="none" stroke="#1a1d24" stroke-width="5" stroke-linecap="round"/>
+  </g>
+
+  <!-- Logo mark: 72×72, centered at x=600, y=237 -->
+  <g transform="translate(564, 201) scale(2.25)">
+    <circle cx="16" cy="16" r="13" fill="none" stroke="#1a1d24" stroke-width="1" opacity=".4"/>
+    <path d="M20.9 12.6 A6 6 0 1 0 20.9 19.4" fill="none" stroke="#1a1d24" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="16" cy="16" r="1.5" fill="#3a5a82"/>
+  </g>
+
+  <!-- Wordmark: "CloudCounsel" -->
+  <text
+    x="600" y="360"
+    text-anchor="middle"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="86"
+    font-weight="400"
+    fill="#1a1d24"
+    letter-spacing="-1.5">CloudCounsel</text>
+
+  <!-- Ltd: manually offset to sit after wordmark (right edge ~935px at this size/font) -->
+  <text
+    x="938" y="323"
+    font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="22"
+    font-weight="500"
+    fill="#636770"
+    letter-spacing="0.5">Ltd</text>
+
+  <!-- Tagline -->
+  <text
+    x="600" y="412"
+    text-anchor="middle"
+    font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="17"
+    fill="#636770"
+    letter-spacing="3.5">SALESFORCE PLATFORM ARCHITECTURE · AUCKLAND, NZ</text>
+
+  <!-- Hairline divider -->
+  <line x1="100" y1="542" x2="1100" y2="542" stroke="#1a1d24" stroke-opacity="0.14" stroke-width="1"/>
+
+  <!-- Bottom badge -->
+  <circle cx="104" cy="572" r="5" fill="#3a5a82"/>
+  <text
+    x="120" y="578"
+    font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+    font-size="15"
+    fill="#636770"
+    letter-spacing="1.5">Architecture-first since 2008</text>
+
+</svg>


### PR DESCRIPTION
- Adds `assets/cloudcounsel-icon.svg` (the CloudCounsel mark from cloudcounsel.co.nz) as a centered, linked logo above the title.
- Adds `assets/cloudcounsel-og.svg` (1200x630 branded card) for you to upload as the repo **Social preview** (Settings -> Social preview).

Note: the header uses a relative path (renders on GitHub). On the npm page relative images don't render — fine for now; can swap to an absolute hosted URL later if desired.