### PR TITLE
docs: absolute raw URL for README logo (renders on npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://cloudcounsel.co.nz"><img src="assets/cloudcounsel-lockup.png" width="240" alt="CloudCounsel Ltd" /></a>
+  <a href="https://cloudcounsel.co.nz"><img src="https://raw.githubusercontent.com/cclabsnz/sf-audit-plugin/main/assets/cloudcounsel-lockup.png" width="240" alt="CloudCounsel Ltd" /></a>
 </p>
 
 # @cclabsnz/sf-audit


### PR DESCRIPTION
Switches the header lockup `img` from a relative path to the absolute raw.githubusercontent.com PNG URL, so the logo also renders on the npm package page (relative paths don't resolve there). Verified the raw URL returns 200 image/png.