### PR TITLE
chore: remove orphaned cloudcounsel-icon.svg

### DIFF
--- a/assets/cloudcounsel-icon.svg
+++ b/assets/cloudcounsel-icon.svg
@@ -1,1 +1,0 @@
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='13' fill='none' stroke='#1a1d24' stroke-width='1' opacity='.4'/><path d='M20.9 12.6 A6 6 0 1 0 20.9 19.4' fill='none' stroke='#1a1d24' stroke-width='5' stroke-linecap='round'/><circle cx='16' cy='16' r='1.5' fill='#3a5a82'/></svg>


### PR DESCRIPTION
Removes the standalone C-mark icon — superseded by the horizontal lockup and referenced nowhere (verified). Keeps `cloudcounsel-lockup.{png,svg}` and `cloudcounsel-og.{png,svg}`.