### PR TITLE
docs: sync Further reading and PERMISSIONS with the checks that shipped

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -1,6 +1,6 @@
 # Minimum Salesforce Permissions for `sf-audit`
 
-`sf audit security` is **strictly read-only**. Every one of the 66 checks issues
+`sf audit security` is **strictly read-only**. Every check issues
 SOQL / Tooling / REST **GET** queries only: no DML, no Metadata API writes, no
 record modification. The account running the audit needs only enough permission
 to *read* security configuration, setup metadata, and audit/login data.
@@ -57,7 +57,7 @@ security team is right to refuse them:
   but for this tool it is used purely to *read* Apex source via Tooling. It does
   not let the audit account modify data or deploy code. If your security policy
   forbids it, omit it: the ~9 code-security checks will report **inconclusive**
-  and the other 57 checks run normally.
+  and every other check runs normally.
 - **Feature/licence-gated checks.** The Event Monitoring and SIEM checks require
   **Event Monitoring / Shield** to be licensed in the org; the Shield
   Platform Encryption portion of Data Classification likewise. Where a feature

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Findings are mapped to controls across eight security and privacy frameworks. Th
 
 > **Not an attestation.** A control rendering "No findings detected" means this audit's checks surfaced no issues mapped to it. It is **not** a statement of compliance or certification. See [Scope & Liability](#scope--liability).
 
-**Further reading:** [Mapping Salesforce security to NZISM, the NZ Privacy Act and ISO 27001](https://www.softwareinsights.dev/posts/salesforce-security-nzism-nz-privacy-act) and [Why Salesforce Health Cloud needs its own security review](https://www.softwareinsights.dev/posts/salesforce-health-cloud-security-review).
+**Further reading:** [Mapping Salesforce security to NZISM, the NZ Privacy Act and ISO 27001](https://softwareinsights.dev/posts/salesforce-security-nzism-nz-privacy-act/) and [Why Salesforce Health Cloud needs its own security review](https://softwareinsights.dev/posts/salesforce-health-cloud-security-review/). More in [Further reading](#further-reading).
 
 ## Scope & Liability
 
@@ -614,14 +614,44 @@ Maintainers: see **[docs/RELEASE.md](docs/RELEASE.md)** for the release checklis
 
 ## Further reading
 
-Deep dives on the topics this tool checks, from our engineering blog **[softwareinsights.dev](https://softwareinsights.dev)**:
+Deep dives on this tool and the topics it checks, from our engineering blog **[softwareinsights.dev](https://softwareinsights.dev)**.
 
-- [How sf-audit works — checks, attack chains, and compliance mapping](https://softwareinsights.dev/posts/sf-audit-61-checks-attack-chains-compliance-mapping/)
+**How the commands work:**
+
+- [How sf-audit works — checks, attack chains, and compliance mapping](https://softwareinsights.dev/posts/sf-audit-61-checks-attack-chains-compliance-mapping/) — the design walkthrough behind `sf audit security`
+- [Free Salesforce Event Monitoring: a baseline from EventLogFile without Shield](https://softwareinsights.dev/posts/salesforce-free-event-monitoring-eventlogfile-baseline/) — why [`sf audit events pull`](#free-event-baseline) exists and how to cron it
+- [Which connected apps use less than they're granted? Ask your own logs](https://softwareinsights.dev/posts/salesforce-connected-app-least-privilege-granted-vs-used/) — the granted-vs-used method behind [`sf audit apps`](#connected-app-least-privilege)
+- [Scanner or breach? Triage EventLogFile in one command](https://softwareinsights.dev/posts/salesforce-eventlogfile-guest-traffic-triage-scanner-or-breach/) — pairing an `events pull` baseline with the [sfelf-triage](https://github.com/cclabsnz/sfelf-triage) companion
+- [Salesforce guest user exposure, graded by real reachability](https://softwareinsights.dev/posts/sf-audit-guest-user-exposure-reachability/) — the UI-API reachability tiering behind the [guest checks](#guest--external-facing-access)
+- [sf-audit vs sf-cli-security-audit](https://softwareinsights.dev/posts/sf-audit-vs-sf-cli-security-audit/) — how this plugin differs from a configurable policy engine, and when to reach for each
+
+**The access model the privilege checks encode** — the reasoning behind [Users, Permissions & Privilege](#users-permissions--privilege):
+
+- [Why your developers don't need Modify All Data](https://softwareinsights.dev/posts/salesforce-developers-modify-all-data-what-they-need-instead/) — part 1 of a four-part series on delivery-team access; feeds Users & Admins and Privileged Access & Shadow Admins
+- [The access model: tiers and roles](https://softwareinsights.dev/posts/salesforce-delivery-team-access-model-tiers-and-roles/) — the tiering that Separation of Duties and Privilege Escalation Permissions test against
+- [Sizing the model to your team](https://softwareinsights.dev/posts/salesforce-access-model-sizing-internal-vs-external-admin-teams/) — internal vs external admins, and what the model costs to run
+- [Deployable permission sets](https://softwareinsights.dev/posts/salesforce-delivery-team-deployable-permission-sets/) — the metadata and the CI identity, which the Integration / Service Accounts check inventories
+
+**Platform changes the checks track:**
+
 - [Hardening Agentforce against prompt injection (post-ForcedLeak)](https://softwareinsights.dev/posts/salesforce-agentforce-forcedleak-prompt-injection-hardening/) — feeds the Agentforce / GenAI checks
+- [Audit your Agentforce footprint: every agent, agent user, and permission](https://softwareinsights.dev/posts/salesforce-agentforce-footprint-audit/) — the manual SOQL behind Agent Inventory
+- [Agentforce agent user least privilege](https://softwareinsights.dev/posts/salesforce-agentforce-agent-user-least-privilege/) — feeds the Agent User Privilege check
 - [Salesforce MFA enforcement: the revised 2026 dates](https://softwareinsights.dev/posts/salesforce-mfa-enforcement-paused-revised-dates-2026/) — feeds the MFA checks
+- [The MFA enforcement admin guide](https://softwareinsights.dev/posts/salesforce-mfa-enforcement-2026-admin-guide/) — what the MFA Enforcement / Registration / Method Strength checks are measuring against
+- [MFA lockout recovery and break-glass accounts](https://softwareinsights.dev/posts/salesforce-mfa-lockout-recovery-break-glass-accounts/) — the operational side of the MFA and High Assurance Session checks
+- [OAuth username-password (ROPC) flow retirement in Winter '27](https://softwareinsights.dev/posts/salesforce-oauth-username-password-flow-retirement-winter-27/) — feeds the SSO Enforcement and Connected App OAuth Scopes checks
+- [Email change verification retirement and Authorized Email Domains](https://softwareinsights.dev/posts/salesforce-email-change-verification-retirement-authorized-email-domains/) — feeds the Email Security check
 - [Summer '26: SAML retirement & Apex secure-by-default](https://softwareinsights.dev/posts/salesforce-summer-26-saml-retirement-apex-secure-by-default/) — feeds the SSO / Apex checks
 - [Salesforce security enforcement in 2026 — every change and date](https://softwareinsights.dev/posts/salesforce-security-enforcement-2026-complete-guide/) — the overall posture this tool measures
 - [Report-export step-up enforcement: known issues](https://softwareinsights.dev/posts/salesforce-transaction-security-policy-report-export-known-issues/) — feeds the data-export / transaction-security checks
+
+**Compliance and NZ context** — background for the [framework mappings](#compliance-frameworks):
+
+- [Mapping Salesforce security to NZISM, the NZ Privacy Act and ISO 27001](https://softwareinsights.dev/posts/salesforce-security-nzism-nz-privacy-act/)
+- [Data sovereignty for New Zealand Salesforce orgs](https://softwareinsights.dev/posts/salesforce-data-sovereignty-new-zealand/) — residency vs sovereignty, and why the `nz` framework pack exists
+- [IPP 3A indirect collection notices](https://softwareinsights.dev/posts/salesforce-nz-privacy-ipp3a-indirect-collection-notice/) — feeds the NZ Privacy Act control mappings
+- [Why Salesforce Health Cloud needs its own security review](https://softwareinsights.dev/posts/salesforce-health-cloud-security-review/) — the HISO 10029 context
 
 ## Commercial support
 


### PR DESCRIPTION
The blog posts written alongside each wave of checks were never linked back from the README, and `PERMISSIONS.md` still advertised a check count from four releases ago.

## Further reading

The list had six entries and was last touched in #28, before `events pull`, `sf audit apps`, the Agentforce checks, and the delivery-team access model landed. Regrouped by what each post actually backs, with twelve posts added:

- **How the commands work** — each command post now deep-links to the matching README section (`events pull` → Free event baseline, `sf audit apps` → Connected-app least-privilege, guest reachability → the guest domain table).
- **The access model the privilege checks encode** — the four-part delivery-team access series. The effective-permission, shadow-admin, and separation-of-duties checks landed in `e0f4a1c`-era work with no link to the reasoning behind them; this is the largest cluster that was missing.
- **Platform changes the checks track** — added the MFA admin guide, break-glass recovery, ROPC retirement, and Authorized Email Domains posts.
- **Compliance and NZ context** — added data sovereignty and IPP 3A, and normalised the inline compliance links to match.

Every slug verified against the live post set; every in-page anchor verified against a real heading.

## PERMISSIONS.md

It claimed "every one of the 66 checks" and "the other 57 checks run normally" while the registry is at 88. The `readme-check-count` test only guards `README.md`, so this drifted silently. Both are now phrased count-free rather than adding a second number to keep in sync.

## Verification

- `readme-check-count` invariants hold: registry 88 / headline 88 / usage 88 / table rows 88.
- No content changes to the check tables, scoring, or compliance mappings.