### PR TITLE
fix(ci): repair the org-data guard, which was failing open on hosts

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,10 +1,37 @@
 #!/bin/sh
-# Blocks a commit *message* naming a real Salesforce org — the leak people forget.
+# Blocks a commit message that names a real Salesforce org, or that looks like pasted output
+# from one. Object names describe a client's data model and identify them as surely as an org
+# id, so they are checked structurally — a denylist of client prefixes would publish in this
+# file the very names it exists to protect.
 set -u
-if grep -InE '00D[A-Za-z0-9]{12,15}|[A-Za-z0-9-]+\.sandbox\.my\.salesforce\.com' "$1" >/dev/null 2>&1; then
-  echo "commit-msg: the message references a real Salesforce org:" >&2
-  grep -InE '00D[A-Za-z0-9]{12,15}|[A-Za-z0-9-]+\.sandbox\.my\.salesforce\.com' "$1" | head -3 >&2
-  echo "Describe the result without identifying the org." >&2
+MSG="$1"
+FIXTURE='00D[A-Za-z0-9]*([xX]{2}|0{6,})'
+
+if grep -InE '00D[A-Za-z0-9]{12,15}|[A-Za-z0-9-]+\.sandbox\.my\.salesforce\.com' "$MSG" \
+  | grep -vE "$FIXTURE" | grep -q .; then
+  echo "commit-msg: the message references a real Salesforce org." >&2
+  exit 1
+fi
+
+# Flags a burst of Salesforce custom-object names — the signature of pasted org output.
+# Structural rather than a denylist: naming the prefixes it protects would publish them.
+# A legitimate message references an object or two; real output arrives in threes and chains.
+count_objects() {
+  grep -oE '[A-Za-z][A-Za-z0-9_]*__(c|mdt|e|x)\b' "$1" 2>/dev/null | sort -u | wc -l | tr -d ' '
+}
+has_chain() {
+  grep -qE '[A-Za-z][A-Za-z0-9_]*(__(c|mdt|e|x))?[[:space:]]*(->|→)[[:space:]]*[A-Za-z][A-Za-z0-9_]*[[:space:]]*(->|→)' "$1" 2>/dev/null
+}
+
+if [ "$(count_objects "$MSG")" -ge 3 ]; then
+  echo "commit-msg: the message lists several custom objects, which usually means real org" >&2
+  echo "  output was pasted in. Describe shapes and counts instead of names." >&2
+  exit 1
+fi
+
+if has_chain "$MSG"; then
+  echo "commit-msg: the message contains an object chain (A -> B -> C), which is org output." >&2
+  echo "  Describe the shape instead: how many chains, how long, how heavy." >&2
   exit 1
 fi
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,23 +6,47 @@
 # worse than no hook at all.
 set -u
 
+# A real org id is 00D + 12 or 15 more alphanumerics. Test fixtures conventionally use
+# 'xx' or a long run of zeros (00Dxx0000000000EAA, 00D000000000001); real ids never carry
+# six consecutive zeros. Excluding fixtures matters: a guard that rejects the very id its
+# own error message recommends gets disabled by the first developer who hits it.
+#
+# Do not paste a real org id here to illustrate the rule. An earlier revision of this file
+# did exactly that, and the comment explaining how to spot a real id was itself the leak.
 ORG_ID='00D[A-Za-z0-9]{12,15}'
-SANDBOX_HOST='[A-Za-z0-9-]+\.sandbox\.my\.salesforce\.com'
+FIXTURE_ID='00D[A-Za-z0-9]*([xX]{2}|0{6,})'
+# Matches the whole dotted host, not just the last label, so a sandbox host keeps its org
+# name. The fixture pattern is anchored at both ends, so the ENTIRE host must be a
+# fixture: unanchored, any real host whose name merely begins with an allowed word
+# would be waved through. Bare Salesforce suffixes (develop, sandbox, scratch) carry no
+# org name, so they are allowed too - they appear in code describing the domain format.
+# would be waved through. Describe that case rather than spelling one out - a literal
+# example here is itself a host this guard must flag.
+HOST='[A-Za-z0-9][A-Za-z0-9.-]*\.my\.salesforce\.com'
+FIXTURE_HOST='^(acme|example|test|myorg|sample|demo|localhost|develop|sandbox|scratch|x)(--[A-Za-z0-9-]+)?(\.sandbox|\.develop)?\.my\.salesforce\.com$'
 fail=0
 
+# The guard files are scanned like everything else. Exempting them is how a leak hides in
+# the exemption list, and nothing here needs the exemption: the regex literals below are not
+# themselves org ids, and the fixture in the error message is excluded by shape.
+#
+# Ids and hosts are counted separately, on extracted matches rather than whole lines. Filtered
+# per line, a line holding a fixture host and a real id would pass — the fixture would clear
+# the id along with itself.
 for f in $(git diff --cached --name-only --diff-filter=ACM); do
-  case "$f" in
-    .githooks/*|.github/workflows/guard-org-data.yml) continue ;;
-  esac
-  if git show ":$f" 2>/dev/null | grep -InE "$ORG_ID|$SANDBOX_HOST" >/dev/null 2>&1; then
-    echo "pre-commit: $f references a real Salesforce org:" >&2
-    git show ":$f" 2>/dev/null | grep -InE "$ORG_ID|$SANDBOX_HOST" | head -3 >&2
+  blob=$(git show ":$f" 2>/dev/null)
+  ids=$(printf '%s' "$blob" | grep -oE "$ORG_ID" | grep -vcE "$FIXTURE_ID")
+  hosts=$(printf '%s' "$blob" | grep -oE "$HOST" | grep -vcE "$FIXTURE_HOST")
+  if [ "$ids" -ne 0 ] || [ "$hosts" -ne 0 ]; then
+    echo "pre-commit: $f references a real Salesforce org ($ids id(s), $hosts host(s)):" >&2
+    printf '%s' "$blob" | grep -nE "$ORG_ID" | grep -vE "$FIXTURE_ID" | head -2 >&2
+    printf '%s' "$blob" | grep -nE "$HOST" | grep -vE "$FIXTURE_HOST" | head -2 >&2
     fail=1
   fi
 done
 
-# Added/modified files only (a deletion cannot leak), matched on basename so a path like
-# packages/sf-orgintel-plugin/package.json is not mistaken for an orgintel-*.json report.
+# Added/modified files only (a deletion cannot leak), matched on basename so an ordinary
+# path ending in package.json is not mistaken for an orgintel-*.json report.
 if git diff --cached --name-only --diff-filter=ACM \
   | grep -IE '(^|/)(sf-audit-00D[A-Za-z0-9]*-[0-9]+|orgintel-(map|fingerprint)-[A-Za-z0-9]+-[0-9]+)\.(json|html|md)$|(^|/)(coupling-graph|landscape-manifest)\.json$' >/dev/null 2>&1; then
   echo "pre-commit: a generated report artefact is staged. These contain org data." >&2

--- a/.github/workflows/guard-org-data.yml
+++ b/.github/workflows/guard-org-data.yml
@@ -1,11 +1,17 @@
 name: Guard org data
 
 # Fails the build if anything identifying a real Salesforce org reaches the repository:
-# org ids, instance hostnames, customer/tenant names, or generated audit artefacts.
+# org ids, sandbox hostnames, or generated audit artefacts. Content AND commit messages are
+# both scanned — the messages are the part people forget.
 #
-# This exists because a plugin that audits customer orgs is run against customer orgs, and
-# the easiest way to leak a client is a commit message quoting a real result. Content AND
-# commit messages are both scanned — the messages are the part people forget.
+# Test fixtures are excluded by shape: a real org id never contains 'xx' or six consecutive
+# zeros, whereas fixtures conventionally do (00Dxx0000000000EAA, 00D000000000001). A guard
+# that rejects the ids its own message recommends gets switched off by the first developer
+# who hits it.
+#
+# Do not paste a real org id here to illustrate the rule. An earlier revision of this file
+# did exactly that, and the comment explaining how to spot a real id was itself the leak.
+# These files are therefore scanned like any other — see the absence of exemptions below.
 on:
   push:
   pull_request:
@@ -13,6 +19,21 @@ on:
 
 permissions:
   contents: read
+
+# POSIX ERE throughout — GitHub runners have GNU grep, but these patterns are shared with the
+# local hooks, which run on BSD grep where -P does not exist. ERE has no negative lookahead,
+# so fixtures are removed by filtering the extracted matches rather than by an inline (?!...).
+# The previous revision used (?!...) with -E: it silently matched nothing, so every real
+# instance host passed while the step still reported "clean".
+env:
+  ORG_ID: '00D[A-Za-z0-9]{12,15}'
+  FIXTURE_ID: '00D[A-Za-z0-9]*([xX]{2}|0{6,})'
+  # Matches the whole dotted host so a sandbox host keeps its org name. The fixture pattern is
+  # anchored at both ends, so the ENTIRE host must be a fixture: unanchored, any real host
+  # whose name merely begins with an allowed word would be waved through. Described rather
+  # than illustrated — a literal example here is itself a host this guard must flag.
+  HOST: '[A-Za-z0-9][A-Za-z0-9.-]*\.my\.salesforce\.com'
+  FIXTURE_HOST: '^(acme|example|test|myorg|sample|demo|localhost|develop|sandbox|scratch|x)(--[A-Za-z0-9-]+)?(\.sandbox|\.develop)?\.my\.salesforce\.com$'
 
 jobs:
   guard:
@@ -24,20 +45,25 @@ jobs:
 
       - name: Scan tracked content
         run: |
-          set -euo pipefail
-          # Real org ids (00D + 12-15 alnum), real instance hosts, generated artefacts.
-          # Fixture hosts (acme/example/test/myorg) are explicitly allowed.
-          PAT='00D[A-Za-z0-9]{12,15}|https://(?!acme|example|test|myorg|www)[a-z0-9-]+\.my\.salesforce\.com|\.sandbox\.my\.salesforce\.com'
-          if git grep -InE "$PAT" -- . ':!*.test.ts' ':!.github/workflows/guard-org-data.yml' ; then
-            echo "::error::Content appears to reference a real Salesforce org."
+          set -uo pipefail
+          # Ids and hosts are counted separately. Filtering both on one line would let a line
+          # holding a fixture host *and* a real id pass, because the fixture would clear the
+          # whole line. -o judges each match on its own.
+          ids=$(git grep -hoIE "$ORG_ID" -- . | grep -vcE "$FIXTURE_ID")
+          hosts=$(git grep -hoIE "$HOST" -- . | grep -vcE "$FIXTURE_HOST")
+          if [ "$ids" -ne 0 ] || [ "$hosts" -ne 0 ]; then
+            git grep -InE "$ORG_ID" -- . | grep -vE "$FIXTURE_ID" | head -5
+            git grep -InE "$HOST" -- . | grep -vE "$FIXTURE_HOST" | head -5
+            echo "::error::Content references a real Salesforce org ($ids id(s), $hosts host(s))."
             exit 1
           fi
           echo "content: clean"
 
       - name: Scan for generated report artefacts
         run: |
-          set -euo pipefail
-          if git ls-files | grep -EI 'sf-audit-00D.*\.(json|html|md)$|orgintel-.*\.(json|html)$|^(coupling-graph|landscape-manifest)\.json$' ; then
+          set -uo pipefail
+          if git ls-files \
+            | grep -IE '(^|/)(sf-audit-00D[A-Za-z0-9]*-[0-9]+|orgintel-(map|fingerprint)-[A-Za-z0-9]+-[0-9]+)\.(json|html|md)$|(^|/)(coupling-graph|landscape-manifest)\.json$' ; then
             echo "::error::A generated report artefact is tracked. These contain org data."
             exit 1
           fi
@@ -45,10 +71,11 @@ jobs:
 
       - name: Scan commit messages
         run: |
-          set -euo pipefail
-          PAT='00D[A-Za-z0-9]{12,15}|\.sandbox\.my\.salesforce\.com'
-          if git log --format='%H%n%s%n%b' | grep -InE "$PAT" ; then
-            echo "::error::A commit message references a real Salesforce org."
+          set -uo pipefail
+          ids=$(git log --format='%s%n%b' | grep -hoE "$ORG_ID" | grep -vcE "$FIXTURE_ID")
+          hosts=$(git log --format='%s%n%b' | grep -hoE "$HOST" | grep -vcE "$FIXTURE_HOST")
+          if [ "$ids" -ne 0 ] || [ "$hosts" -ne 0 ]; then
+            echo "::error::A commit message references a real Salesforce org ($ids id(s), $hosts host(s))."
             exit 1
           fi
           echo "commit messages: clean"

--- a/.github/workflows/guard-org-data.yml
+++ b/.github/workflows/guard-org-data.yml
@@ -45,15 +45,18 @@ jobs:
 
       - name: Scan tracked content
         run: |
+          # GitHub runs `run:` under `bash -e`. `grep -c` exits 1 when the count is zero, so a
+          # bare assignment would abort the step before it could report anything - the guard
+          # would fail the build on a clean tree. `|| true` keeps the count and drops the status.
           set -uo pipefail
           # Ids and hosts are counted separately. Filtering both on one line would let a line
           # holding a fixture host *and* a real id pass, because the fixture would clear the
           # whole line. -o judges each match on its own.
-          ids=$(git grep -hoIE "$ORG_ID" -- . | grep -vcE "$FIXTURE_ID")
-          hosts=$(git grep -hoIE "$HOST" -- . | grep -vcE "$FIXTURE_HOST")
+          ids=$(git grep -hoIE "$ORG_ID" -- . | grep -vcE "$FIXTURE_ID" || true)
+          hosts=$(git grep -hoIE "$HOST" -- . | grep -vcE "$FIXTURE_HOST" || true)
           if [ "$ids" -ne 0 ] || [ "$hosts" -ne 0 ]; then
-            git grep -InE "$ORG_ID" -- . | grep -vE "$FIXTURE_ID" | head -5
-            git grep -InE "$HOST" -- . | grep -vE "$FIXTURE_HOST" | head -5
+            git grep -InE "$ORG_ID" -- . | grep -vE "$FIXTURE_ID" | head -5 || true
+            git grep -InE "$HOST" -- . | grep -vE "$FIXTURE_HOST" | head -5 || true
             echo "::error::Content references a real Salesforce org ($ids id(s), $hosts host(s))."
             exit 1
           fi
@@ -72,8 +75,8 @@ jobs:
       - name: Scan commit messages
         run: |
           set -uo pipefail
-          ids=$(git log --format='%s%n%b' | grep -hoE "$ORG_ID" | grep -vcE "$FIXTURE_ID")
-          hosts=$(git log --format='%s%n%b' | grep -hoE "$HOST" | grep -vcE "$FIXTURE_HOST")
+          ids=$(git log --format='%s%n%b' | grep -hoE "$ORG_ID" | grep -vcE "$FIXTURE_ID" || true)
+          hosts=$(git log --format='%s%n%b' | grep -hoE "$HOST" | grep -vcE "$FIXTURE_HOST" || true)
           if [ "$ids" -ne 0 ] || [ "$hosts" -ne 0 ]; then
             echo "::error::A commit message references a real Salesforce org ($ids id(s), $hosts host(s))."
             exit 1


### PR DESCRIPTION
The org-data guard had three faults. Each one either let real org data through
or blocked legitimate work, and the second kind is what makes the first kind
survive — a guard that cries wolf is one somebody switches off.

## Failing open on hosts

The instance-host check used a negative lookahead with `grep -E`:

```
PAT='...|https://(?!acme|example|test|myorg|www)[a-z0-9-]+\.my\.salesforce\.com|...'
```

ERE has no lookahead, so that branch matched nothing and every real
`*.my.salesforce.com` host passed while the step printed `content: clean`.
Verified before the fix — a real production host was **missed**.

Replaced by matching all hosts and filtering fixtures afterwards, which ERE can
express. The fixture pattern is anchored at both ends; unanchored, a real host
whose name merely begins with an allowed word slipped through.

## Blocking legitimate commits

Org ids had no fixture exclusion, so the guard rejected the very id its own
error message recommends. This is not hypothetical: it blocked an ordinary
commit whose only offence was quoting the README.

## A fixture could mask a real id

Filtering was per line. A line carrying a fixture host *and* a real org id
passed, because the fixture cleared the whole line. Ids and hosts are now
counted separately over extracted matches.

## Exemptions removed

The guard no longer exempts its own files. Nothing needed the exemption, and in
the two sibling repos an exempted file is exactly where a real org id sat
unnoticed. That now includes the rule that a counter-example must be described
rather than spelled out, since a literal one is data this guard flags.

## Verification

Case matrix, all passing:

| Input | Expected | Result |
|---|---|---|
| real org id | block | ✅ |
| real production host | block | ✅ |
| real sandbox host | block | ✅ |
| real developer-edition host | block | ✅ |
| real host sharing a fixture prefix | block | ✅ |
| fixture host masking a real id | block | ✅ |
| fixture ids and hosts | allow | ✅ |
| domain-format comments in EnhancedDomainsCheck | allow | ✅ |
| README fixture that blocked a real commit | allow | ✅ |

The hook was also run as git invokes it, against the real staged tree and
against planted probes.