### PR TITLE
chore(ci): move every codeql-action reference to v4.37.3 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,7 +36,7 @@ jobs:
             --sarif --output semgrep.sarif || true
 
       - name: Upload findings to code scanning
-        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: semgrep.sarif
           category: semgrep


### PR DESCRIPTION
Dependabot split one atomic change into three PRs that each fail alone.

CodeQL refuses to run when `init` and `analyze` versions differ. #34 (init only)
failed exactly this way:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '3.37.3'
```

All four `codeql-action` references pinned the same v3 commit, and Dependabot
proposed the same v4 commit (`e4fba868…`, v4.37.3) for each — so they move
together or not at all.

| File | Action |
|---|---|
| `codeql.yml` | `init`, `analyze` |
| `scorecard.yml` | `upload-sarif` |
| `semgrep.yml` | `upload-sarif` |

Supersedes #34, #35, #37 — closing those in favour of this.