### PR TITLE
chore(deps): move to @salesforce/core 9 and sf-plugins-core 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@cclabsnz/sf-core": "^0.1.4",
     "@oclif/core": "^4",
-    "@salesforce/core": "^8",
-    "@salesforce/sf-plugins-core": "^12",
+    "@salesforce/core": "^9",
+    "@salesforce/sf-plugins-core": "^13",
     "chart.js": "^4.5.1",
     "zod": "^4"
   },

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {
-    "@cclabsnz/sf-core": "^0.1.4",
     "@oclif/core": "^4",
     "@salesforce/core": "^9",
     "@salesforce/sf-plugins-core": "^13",
     "chart.js": "^4.5.1",
-    "zod": "^4"
+    "zod": "^4",
+    "@cclabsnz/sf-core": "^0.1.5"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   handlebars: ^4.7.9
   brace-expansion: ^5.0.8
   fast-uri@3: ^3.1.4
+  '@salesforce/core': ^9
 
 importers:
 
@@ -22,11 +23,11 @@ importers:
         specifier: ^4
         version: 4.13.0
       '@salesforce/core':
-        specifier: ^8
-        version: 8.32.6
+        specifier: ^9
+        version: 9.1.0
       '@salesforce/sf-plugins-core':
-        specifier: ^12
-        version: 12.2.28(@types/node@22.19.20)
+        specifier: ^13
+        version: 13.0.0(@types/node@22.19.20)
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -477,16 +478,32 @@ packages:
     resolution: {integrity: sha512-ZR973WoqCgi6cR58WhgokbHVZOaADNKHiuM1FAwS5pTLQnC91xYi04i2e/gpAX2AUf7Ya6zjbusYtZNpSyKKAQ==}
     engines: {node: '>=18.0.0'}
 
+  '@salesforce/core@9.1.0':
+    resolution: {integrity: sha512-ID9g4YH0yZBeWI0eKJv2IJRRN6ZuNjwpIOjEZm9a79Gzxa3IITsV4PCvD8q7JA3PKqiln57p8yJE458Kn5KW1g==}
+    engines: {node: '>=22.0.0'}
+
   '@salesforce/kit@3.2.6':
     resolution: {integrity: sha512-O8S4LWerHa9Zosqh+IoQjgLtpxMOfObRxaRnUdRV4MLtFUi+bQxQiyFvve6eEaBaMP1b1xVDQpvSvQ+PXEDGFQ==}
+
+  '@salesforce/kit@4.0.0':
+    resolution: {integrity: sha512-VwxhSH/8PQ5YmPAdhmLaJGCgR0n/pOm8T2y+/odMFthd5SA0xsO/kTdaRLFnFQAxxNj1nYtNHRb+BoMuAatzew==}
+    engines: {node: '>=22.0.0'}
 
   '@salesforce/sf-plugins-core@12.2.28':
     resolution: {integrity: sha512-amfPBfdlgYoM9LCQewtoLWOe29kY7urLnYH1a5G7QLWN74tJeXEkvc1OyM18n+f2MHmpK0/ICAg5Wq276HwxHQ==}
     engines: {node: '>=18.0.0'}
 
+  '@salesforce/sf-plugins-core@13.0.0':
+    resolution: {integrity: sha512-enKeAfswRyqWN6mcs0HkN+oMnJzUwJIs+Aea8U6NZsdvAdzVEZP4e7vHTPhIQ6esQeGAIf+miPJ8hOITCrDK/A==}
+    engines: {node: '>=22.0.0'}
+
   '@salesforce/ts-types@2.0.12':
     resolution: {integrity: sha512-BIJyduJC18Kc8z+arUm5AZ9VkPRyw1KKAm+Tk+9LT99eOzhNilyfKzhZ4t+tG2lIGgnJpmytZfVDZ0e2kFul8g==}
     engines: {node: '>=18.0.0'}
+
+  '@salesforce/ts-types@3.0.1':
+    resolution: {integrity: sha512-NWkveMYT2I3O7EAYwWHi6/ba2YUwp9MFi/zJzA+czK5MVqJfdD6FZbiQrTbALZNvFzgFSdq9BvHm6ygRmtROzw==}
+    engines: {node: '>=22.0.0'}
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -2384,7 +2401,7 @@ snapshots:
 
   '@cclabsnz/sf-core@0.1.4':
     dependencies:
-      '@salesforce/core': 8.32.6
+      '@salesforce/core': 9.1.0
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -2733,9 +2750,35 @@ snapshots:
       ts-retry-promise: 0.8.1
       zod: 4.4.3
 
+  '@salesforce/core@9.1.0':
+    dependencies:
+      '@jsforce/jsforce-node': 3.10.19
+      '@salesforce/kit': 4.0.0
+      '@salesforce/ts-types': 3.0.1
+      ajv: 8.20.0
+      change-case: 4.1.2
+      fast-levenshtein: 3.0.0
+      faye: 1.4.1
+      form-data: 4.0.6
+      js2xmlparser: 4.0.2
+      jsonwebtoken: 9.0.3
+      jszip: 3.10.1
+      memfs: 4.38.1
+      pino: 9.14.0
+      pino-abstract-transport: 1.2.0
+      pino-pretty: 11.3.0
+      proper-lockfile: 4.1.2
+      semver: 7.8.5
+      ts-retry-promise: 0.8.1
+      zod: 4.4.3
+
   '@salesforce/kit@3.2.6':
     dependencies:
       '@salesforce/ts-types': 2.0.12
+
+  '@salesforce/kit@4.0.0':
+    dependencies:
+      '@salesforce/ts-types': 3.0.1
 
   '@salesforce/sf-plugins-core@12.2.28(@types/node@22.19.20)':
     dependencies:
@@ -2755,7 +2798,27 @@ snapshots:
       - react-devtools-core
       - utf-8-validate
 
+  '@salesforce/sf-plugins-core@13.0.0(@types/node@22.19.20)':
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@22.19.20)
+      '@inquirer/password': 5.1.1(@types/node@22.19.20)
+      '@oclif/core': 4.13.0
+      '@oclif/table': 0.5.9
+      '@salesforce/core': 9.1.0
+      '@salesforce/kit': 4.0.0
+      '@salesforce/ts-types': 3.0.1
+      ansis: 3.17.0
+      cli-progress: 3.12.0
+      terminal-link: 3.0.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - react-devtools-core
+      - utf-8-validate
+
   '@salesforce/ts-types@2.0.12': {}
+
+  '@salesforce/ts-types@3.0.1': {}
 
   '@sinclair/typebox@0.27.10': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,15 +10,14 @@ overrides:
   handlebars: ^4.7.9
   brace-expansion: ^5.0.8
   fast-uri@3: ^3.1.4
-  '@salesforce/core': ^9
 
 importers:
 
   .:
     dependencies:
       '@cclabsnz/sf-core':
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: ^0.1.5
+        version: 0.1.5(@salesforce/core@9.1.0)
       '@oclif/core':
         specifier: ^4
         version: 4.13.0
@@ -57,48 +56,7 @@ importers:
         specifier: ^5
         version: 5.9.3
 
-  packages/sf-audit-plugin:
-    dependencies:
-      '@cclabsnz/sf-core':
-        specifier: ^0.1.0
-        version: 0.1.0
-      '@oclif/core':
-        specifier: ^4
-        version: 4.13.0
-      '@salesforce/core':
-        specifier: ^8
-        version: 8.32.6
-      '@salesforce/sf-plugins-core':
-        specifier: ^12
-        version: 12.2.28(@types/node@22.19.20)
-      chart.js:
-        specifier: ^4.5.1
-        version: 4.5.1
-      zod:
-        specifier: ^4
-        version: 4.4.3
-    devDependencies:
-      '@jest/globals':
-        specifier: ^29.7.0
-        version: 29.7.0
-      '@types/jest':
-        specifier: ^29
-        version: 29.5.14
-      '@types/node':
-        specifier: ^22
-        version: 22.19.20
-      jest:
-        specifier: ^29
-        version: 29.7.0(@types/node@22.19.20)(ts-node@10.9.2(@types/node@22.19.20)(typescript@5.9.3))
-      ts-jest:
-        specifier: ^29
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.20)(ts-node@10.9.2(@types/node@22.19.20)(typescript@5.9.3)))(typescript@5.9.3)
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.20)(typescript@5.9.3)
-      typescript:
-        specifier: ^5
-        version: 5.9.3
+  packages/sf-audit-plugin: {}
 
 packages:
 
@@ -271,13 +229,11 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@cclabsnz/sf-core@0.1.0':
-    resolution: {integrity: sha512-4Iv78srKrErZFIe9CbcainR0SZv1HoS5LocbzOHrmeQxSpnC1D4oBmN4UPX1X4uEeeQJ06Q52ZY/sKtcW2xnJQ==}
+  '@cclabsnz/sf-core@0.1.5':
+    resolution: {integrity: sha512-PJ9FFvbp+sI3djrID5uZoQUVxNDufg1le07Nryu7vek3t7tkRf1jaA0fvZFvP6ohcr88WJ8qES2SnTTIM7i0nQ==}
     engines: {node: '>=18.0.0'}
-
-  '@cclabsnz/sf-core@0.1.4':
-    resolution: {integrity: sha512-BpKJaa56s9O8Z4dDQ+sCtKoPvQvXnZpVwMEMM+CrauKCnT6zvuYbKiNkZaCJHZ/w/Qw+AbCcMkchKlf9FloIXw==}
-    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@salesforce/core': ^8 || ^9
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -474,32 +430,17 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@salesforce/core@8.32.6':
-    resolution: {integrity: sha512-ZR973WoqCgi6cR58WhgokbHVZOaADNKHiuM1FAwS5pTLQnC91xYi04i2e/gpAX2AUf7Ya6zjbusYtZNpSyKKAQ==}
-    engines: {node: '>=18.0.0'}
-
   '@salesforce/core@9.1.0':
     resolution: {integrity: sha512-ID9g4YH0yZBeWI0eKJv2IJRRN6ZuNjwpIOjEZm9a79Gzxa3IITsV4PCvD8q7JA3PKqiln57p8yJE458Kn5KW1g==}
     engines: {node: '>=22.0.0'}
-
-  '@salesforce/kit@3.2.6':
-    resolution: {integrity: sha512-O8S4LWerHa9Zosqh+IoQjgLtpxMOfObRxaRnUdRV4MLtFUi+bQxQiyFvve6eEaBaMP1b1xVDQpvSvQ+PXEDGFQ==}
 
   '@salesforce/kit@4.0.0':
     resolution: {integrity: sha512-VwxhSH/8PQ5YmPAdhmLaJGCgR0n/pOm8T2y+/odMFthd5SA0xsO/kTdaRLFnFQAxxNj1nYtNHRb+BoMuAatzew==}
     engines: {node: '>=22.0.0'}
 
-  '@salesforce/sf-plugins-core@12.2.28':
-    resolution: {integrity: sha512-amfPBfdlgYoM9LCQewtoLWOe29kY7urLnYH1a5G7QLWN74tJeXEkvc1OyM18n+f2MHmpK0/ICAg5Wq276HwxHQ==}
-    engines: {node: '>=18.0.0'}
-
   '@salesforce/sf-plugins-core@13.0.0':
     resolution: {integrity: sha512-enKeAfswRyqWN6mcs0HkN+oMnJzUwJIs+Aea8U6NZsdvAdzVEZP4e7vHTPhIQ6esQeGAIf+miPJ8hOITCrDK/A==}
     engines: {node: '>=22.0.0'}
-
-  '@salesforce/ts-types@2.0.12':
-    resolution: {integrity: sha512-BIJyduJC18Kc8z+arUm5AZ9VkPRyw1KKAm+Tk+9LT99eOzhNilyfKzhZ4t+tG2lIGgnJpmytZfVDZ0e2kFul8g==}
-    engines: {node: '>=18.0.0'}
 
   '@salesforce/ts-types@3.0.1':
     resolution: {integrity: sha512-NWkveMYT2I3O7EAYwWHi6/ba2YUwp9MFi/zJzA+czK5MVqJfdD6FZbiQrTbALZNvFzgFSdq9BvHm6ygRmtROzw==}
@@ -2395,11 +2336,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@cclabsnz/sf-core@0.1.0':
-    dependencies:
-      '@salesforce/core': 8.32.6
-
-  '@cclabsnz/sf-core@0.1.4':
+  '@cclabsnz/sf-core@0.1.5(@salesforce/core@9.1.0)':
     dependencies:
       '@salesforce/core': 9.1.0
 
@@ -2728,28 +2665,6 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
-  '@salesforce/core@8.32.6':
-    dependencies:
-      '@jsforce/jsforce-node': 3.10.19
-      '@salesforce/kit': 3.2.6
-      '@salesforce/ts-types': 2.0.12
-      ajv: 8.20.0
-      change-case: 4.1.2
-      fast-levenshtein: 3.0.0
-      faye: 1.4.1
-      form-data: 4.0.6
-      js2xmlparser: 4.0.2
-      jsonwebtoken: 9.0.3
-      jszip: 3.10.1
-      memfs: 4.38.1
-      pino: 9.14.0
-      pino-abstract-transport: 1.2.0
-      pino-pretty: 11.3.0
-      proper-lockfile: 4.1.2
-      semver: 7.8.5
-      ts-retry-promise: 0.8.1
-      zod: 4.4.3
-
   '@salesforce/core@9.1.0':
     dependencies:
       '@jsforce/jsforce-node': 3.10.19
@@ -2772,31 +2687,9 @@ snapshots:
       ts-retry-promise: 0.8.1
       zod: 4.4.3
 
-  '@salesforce/kit@3.2.6':
-    dependencies:
-      '@salesforce/ts-types': 2.0.12
-
   '@salesforce/kit@4.0.0':
     dependencies:
       '@salesforce/ts-types': 3.0.1
-
-  '@salesforce/sf-plugins-core@12.2.28(@types/node@22.19.20)':
-    dependencies:
-      '@inquirer/confirm': 6.1.1(@types/node@22.19.20)
-      '@inquirer/password': 5.1.1(@types/node@22.19.20)
-      '@oclif/core': 4.13.0
-      '@oclif/table': 0.5.9
-      '@salesforce/core': 8.32.6
-      '@salesforce/kit': 3.2.6
-      '@salesforce/ts-types': 2.0.12
-      ansis: 3.17.0
-      cli-progress: 3.12.0
-      terminal-link: 3.0.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - utf-8-validate
 
   '@salesforce/sf-plugins-core@13.0.0(@types/node@22.19.20)':
     dependencies:
@@ -2815,8 +2708,6 @@ snapshots:
       - bufferutil
       - react-devtools-core
       - utf-8-validate
-
-  '@salesforce/ts-types@2.0.12': {}
 
   '@salesforce/ts-types@3.0.1': {}
 


### PR DESCRIPTION
Completes #43, which could not compile as Dependabot raised it.

## Why #43 failed

`@cclabsnz/sf-core` declared `@salesforce/core` as a runtime **dependency**, so
bumping this package to v9 installed a second copy underneath sf-core and the
two `Connection` types refused to unify:

```
src/lib/wire.ts(11,30): error TS2345:
  Connection<...@salesforce+core@9.1.0...> is not assignable to
  Connection<...@salesforce+core@8.32.6...>
```

## The upstream fix

Every reference to `@salesforce/core` inside sf-core is an `import type` — the
built output has 4 `.d.ts` mentions and **0** `.js` mentions. It was never a
runtime dependency. sf-core 0.1.5 moves it to a **peer dependency** with range
`^8 || ^9`, so the consumer supplies the single copy. sf-core now ships with no
runtime dependencies at all.

The range spans both majors deliberately — narrowing it would recreate the
lockstep coupling that caused this bug.

## Result

The lockfile records one resolution:

```
'@cclabsnz/sf-core':
  specifier: ^0.1.5
  version: 0.1.5(@salesforce/core@9.1.0)
```

and exactly one `@salesforce/core@9.1.0` in the tree.

Stale orphan entries left by the transition (`sf-core@0.1.0`,
`@salesforce/core@8.32.6`, `@salesforce/kit@3.2.6`) are pruned. They were
uninstalled and unreferenced, but an inert entry in a committed lockfile is
still something a reader has to rule out.

## Verification

Clean install from the registry: build clean, **400 tests across 69 suites**,
`pnpm install --frozen-lockfile` reproducible, `pnpm audit --prod` clean.

`sf-orgintel` was moved to v9 on the same sf-core release and is also green
(232 tests) — both consumers verified against the same build.