### PR TITLE
chore(release): 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cclabsnz/sf-audit",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Salesforce Security Audit — native sf plugin",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Version bump for release. 62 commits since 1.6.1.

Minor rather than patch: the dependency floor moved a major (`@salesforce/core` 9, `sf-plugins-core` 13) and generated reports changed behaviour by becoming self-contained (no CDN fetches).

Minor rather than major: no command, flag, or output contract changed for anyone using the plugin.

Merging this then cutting the `v1.7.0` release triggers `publish.yml` — which also gives the first real exercise of `setup-node@v7` and `pnpm/action-setup@v6` on the release path.