### PR TITLE
chore(release): 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cclabsnz/sf-audit",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Salesforce Security Audit — native sf plugin",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Version bump for release. 24 commits since 1.7.0.

**Minor, not major** — nothing existing changed shape. No command, flag or output contract moved,
the check count is unchanged, and the security grade is unaffected: `sf audit timeline` is an
investigation command, not a `SecurityCheck`.

**Minor, not patch** — a user gets a command they did not have.

## What ships

`sf audit timeline` reconstructs one actor's activity across every captured event type, entirely
offline against `sf audit events pull` captures. Four event types carry no `CLIENT_IP` at all, so
filtering by address finds a fraction of the activity; this correlates across the keys that do
connect them, refuses to expand through blank or shared identities, and states what was captured
so an empty result is never read as an absence.

Also in this release: `@cclabsnz/sf-core` 0.3.0, security overrides raised to the patched
`fast-uri` 3.1.5 and `brace-expansion` 5.0.9, and a correctness fix to `NamedCredentialsCheck`
where a credential label containing regex metacharacters could crash the check or silently match
the wrong thing.

## Verification

Build clean, **629 tests across 85 suites**, `pnpm install --frozen-lockfile` reproducible,
`pnpm audit --prod` clean, and the packed tarball contains the new command (325 files, 274.6 kB).

Merging this then cutting the `v1.8.0` release triggers `publish.yml`, which publishes with OIDC
trusted publishing and provenance.