### PR TITLE
chore(ci): bump pinned actions (codeql-action v4.37.4, upload-artifact v7.0.1, action-gh-release v3.0.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: coverage/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,6 +75,6 @@ jobs:
 
       - name: Attach SBOM to the release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: sbom.cyclonedx.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,12 +30,12 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,7 +36,7 @@ jobs:
             --sarif --output semgrep.sarif || true
 
       - name: Upload findings to code scanning
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: semgrep.sarif
           category: semgrep


### PR DESCRIPTION
Supersedes Dependabot PRs #56, #57, #58, #59.

## Why one PR instead of four

Dependabot split the `github/codeql-action` bump into three PRs — `init` (#58), `analyze` (#56), `upload-sarif` (#59). `init` and `analyze` both live in `codeql.yml` and **must move in the same commit**. Merging either alone leaves the workflow mismatched, which is exactly why #56 and #58 are red:

```
##[error]Loaded a configuration file for version '4.37.4', but running version '4.37.3'
CodeQL job status was configuration error.
```

Since `analyze (javascript-typescript)` is a required check and branch protection is strict, landing these serially would also mean a full CI cycle per PR. Grouping them is one cycle.

## Changes

| Action | From | To | Files |
|---|---|---|---|
| `github/codeql-action/{init,analyze}` | v4.37.3 | v4.37.4 | `codeql.yml` |
| `github/codeql-action/upload-sarif` | v4.37.3 | v4.37.4 | `semgrep.yml`, `scorecard.yml` |
| `actions/upload-artifact` | v4 | v7.0.1 | `ci.yml`, `scorecard.yml` |
| `softprops/action-gh-release` | v2 | v3.0.2 | `publish.yml` |

## Notes

- Every pinned SHA was verified against the upstream annotated tag it claims to be, not just taken from the Dependabot diff.
- `action-gh-release` v3 is a runtime-only major (Node 20 → Node 24), no input/output changes. It is only exercised by `publish.yml` on a published release, so PR CI does not cover it — worth watching on the next release cut.

Not included: #55 (`typescript` 5.9.3 → 7.0.2). TypeScript 7 is the native compiler and does not expose the JS compiler API `ts-jest` needs; the whole suite fails to run. That needs a separate test-runner migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)