### PR TITLE
fix(deps): bump js-yaml override to ^3.15.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "pnpm": {
     "overrides": {
       "form-data": "^4.0.6",
-      "js-yaml@3": "^3.15.0",
+      "js-yaml@3": "^3.15.1",
       "handlebars": "^4.7.9",
       "brace-expansion": "^5.0.9",
       "fast-uri@3": "^3.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   form-data: ^4.0.6
-  js-yaml@3: ^3.15.0
+  js-yaml@3: ^3.15.1
   handlebars: ^4.7.9
   brace-expansion: ^5.0.9
   fast-uri@3: ^3.1.5
@@ -1737,8 +1737,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   js2xmlparser@4.0.2:
@@ -2750,7 +2750,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -4380,7 +4380,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
Closes Dependabot alert [#27](https://github.com/cclabsnz/sf-audit-plugin/security/dependabot/27) — the only open alert on the repo.

| | |
|---|---|
| Advisory | GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, not backported past 3.15.0) |
| Severity | High — quadratic CPU consumption in `!!omap` resolution |
| Vulnerable | `>= 3.0.0, < 3.15.1` |
| Patched | `3.15.1` |
| Scope | development, transitive |

## The one-line cause

`pnpm.overrides` already pinned `"js-yaml@3": "^3.15.0"` — exactly one patch short of the fix. The caret does not help here because 3.15.1 is the patched release and the pin was floor-ed at 3.15.0, so the resolver was free to sit on the vulnerable version, and did.

Bumping the floor to `^3.15.1` is the whole change; no direct dependency moves.

## Reach

`js-yaml` is dev-only and transitive — jest coverage tooling, via `@istanbuljs/load-nyc-config` → `babel-plugin-istanbul`. It is not in the published runtime, so the practical exposure is CI and local test runs parsing untrusted YAML, which this repo does not do. Worth fixing regardless since the patch is a floor bump.

## Verification

- `pnpm why js-yaml` now resolves `js-yaml@3.15.1`
- No other `js-yaml` version remains anywhere in `pnpm-lock.yaml`
- `pnpm run build` clean, 85 suites / 629 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)