### PR TITLE
chore: release 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cclabsnz/sf-audit",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Read-only Salesforce security audit for the sf CLI: 88 checks, attack-chain correlation, A-F risk grading, and compliance mapping to OWASP, SOC 2, ISO 27001, NZISM and more.",
   "keywords": [
     "salesforce",


### PR DESCRIPTION
Version bump for the 5 commits sitting on `main` since `v1.8.1`. All maintenance — no user-facing behaviour changed, so this is a patch.

| | |
|---|---|
| #64 | js-yaml override → `^3.15.1`, closing Dependabot alert #27 (high) |
| #62 | typescript 5.9.3 → 7.0.2; ts-jest → @swc/jest; explicit `typecheck` step |
| #61 | pinned actions: codeql-action v4.37.4, upload-artifact v7.0.1, action-gh-release v3.0.2 |
| #63 | README blog links → canonical www host |
| #54 | @oclif/core 4.13.0 → 4.13.2 |

## Pre-release checks (docs/RELEASE.md step 2)

| Check | Result |
|---|---|
| `pnpm run build` | clean |
| `pnpm test` | 85 suites / 629 tests pass |
| `readonly-invariant` + `network-egress` | 4/4 pass — both are release blockers, run explicitly |
| `pnpm audit --prod --audit-level high` | no known vulnerabilities |
| Open Dependabot alerts | 0 |

README check count and flags are unchanged, since no checks were added or removed.

## Note for the release cut

Publishing this release is the **first time `action-gh-release` v3 will actually run**. It came in via #61 and `publish.yml` only fires on a published Release, so no CI run has exercised it. It's a runtime-only major (Node 20 → Node 24, no input or output changes), but it is the most likely thing to break in this publish — worth watching the run rather than firing and walking away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)