### PR TITLE
ci(publish): stop anchore/sbom-action double-attaching the SBOM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,11 @@ jobs:
         with:
           format: cyclonedx-json
           output-file: sbom.cyclonedx.json
+          # Generate only — the next step does the attaching. This input defaults to true,
+          # which uploads a second, identically-sized copy of the SBOM to the release under
+          # its own name (`<repo>-<job>.cyclonedx.json`). Every release up to v1.8.2 carried
+          # both. Keep the explicit attachment, whose filename we control.
+          upload-release-assets: "false"
 
       - name: Attach SBOM to the release
         if: github.event_name == 'release'


### PR DESCRIPTION
Every release through v1.8.2 carries two identical SBOM assets:

```
sbom.cyclonedx.json                     869525 bytes
sf-audit-plugin-publish.cyclonedx.json  869525 bytes
```

## Cause

`anchore/sbom-action`'s `upload-release-assets` input defaults to `"true"` (confirmed against the pinned SHA `e22c389`, not from memory). On a `release` event it uploads its own copy under a generated `<repo>-<job>` name — and then the explicit **Attach SBOM to the release** step attaches a second under the name we chose.

So the generate step was quietly doing the attach step's job as well.

## Fix

Set `upload-release-assets: "false"` so the anchore step only generates. The attachment stays with `action-gh-release`, whose filename we control — `sbom.cyclonedx.json` is kept, the generated-name duplicate goes away.

## Scope

Cosmetic. No change to SBOM contents, npm provenance, or the published package. Workflow YAML re-parsed to confirm both steps still resolve as intended.

This takes effect on the **next** release — v1.8.2 and earlier keep both assets, since release assets are attached at publish time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)