### PR TITLE
docs: reflect the swc/typecheck split and two Dependabot traps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,11 @@ sf audit security --target-org <alias>
 - **Package manager:** the lockfile is `pnpm-lock.yaml`. Use `pnpm` to add
   dependencies; npm scripts (`npm run build`, `npm test`) are fine for running.
 - **ESM/NodeNext:** relative imports must end in `.js` even inside `.ts` files.
+- **Types are checked separately from tests.** Jest transforms with swc, which strips
+  types without checking them, so a type error will *not* fail `npx jest`. `npm test`
+  runs `npm run typecheck` (`tsc --noEmit` over `src` + `test`) first for that reason.
+  `npm run test:jest` skips it when you want a fast inner loop — just don't read it as
+  a green run.
 - After editing commands or checks, re-run `npm run build`. `oclif.pluginType`
   is `jit` and the command dir is `lib/`, so a "missing" command usually means
   you forgot to build.
@@ -53,7 +58,7 @@ the source-of-truth listing.
 ## Before you open a pull request
 
 - `npm run build` is clean.
-- `npm test` is green (Jest, ESM). New/changed checks ship with unit tests.
+- `npm test` is green (typecheck + Jest, ESM). New/changed checks ship with unit tests.
 - Registry ordering still validates and every new check id has a compliance
   mapping and `CHECK_META` entry.
 - README counts/flags are updated if user-facing behaviour changed.

--- a/README.md
+++ b/README.md
@@ -820,10 +820,16 @@ sf audit apps --target-org myOrg --format json
 
 ```bash
 npm run build          # compile TypeScript
-npm test               # run all tests
-npm run test:unit      # unit tests only
+npm run typecheck      # type-check src + test (tsc --noEmit)
+npm test               # typecheck, then run all tests
+npm run test:unit      # typecheck, then unit tests only
+npm run test:jest      # tests without the typecheck — fast inner loop
 npm run clean          # remove compiled output
 ```
+
+Jest transforms with [swc](https://swc.rs), which strips types without checking them, so
+`npm run typecheck` is what catches type errors in tests — it runs ahead of Jest in
+`npm test`. Use `npm run test:jest` while iterating, but don't treat it as a green run.
 
 Maintainers: see **[docs/RELEASE.md](docs/RELEASE.md)** for the release checklist and the one-time repository-hardening steps (npm provenance token, branch protection, and the CodeQL / Scorecard setup behind the badges above).
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -68,10 +68,13 @@ resolves after the first successful run:
 2. **Green locally.**
    ```bash
    pnpm install --frozen-lockfile
-   pnpm run build      # clean tsc
-   pnpm test           # all suites incl. read-only invariant
+   pnpm run build      # clean tsc (src only)
+   pnpm test           # typecheck (src + test), then all suites incl. read-only invariant
    pnpm audit --prod --audit-level high
    ```
+   `pnpm test` runs `typecheck` first because Jest transforms with swc, which strips
+   types without checking them. Don't substitute `pnpm run test:jest` here — it skips
+   the type-check and will go green on code that does not compile.
 3. **Commit & push** the version bump; open a PR; let CI + CodeQL go green; merge.
 4. **Tag & GitHub Release.** Create a release whose tag matches the version (e.g.
    `v1.7.0`). Publishing the release triggers `publish.yml`, which:
@@ -93,6 +96,18 @@ resolves after the first successful run:
 - **Dependabot** opens weekly PRs for npm deps and GitHub Actions (including SHA-pinned
   actions — it updates both the SHA and the `# vN` comment). Merge promptly; security
   fixes arrive as their own PRs.
+- **`github/codeql-action/*` bumps must be merged together.** Dependabot raises `init`,
+  `analyze` and `upload-sarif` as *separate* PRs, but `init` and `analyze` both live in
+  `codeql.yml`. Merging one alone leaves the workflow mismatched and CodeQL fails with
+  `Loaded a configuration file for version 'X', but running version 'Y'` — and since
+  `analyze (javascript-typescript)` is a required check, that blocks `main`. Combine them
+  into one branch, then close the individual PRs as superseded.
+- **A Dependabot alert can outlive its fix.** Check the alert's `first_patched_version`
+  against what the lockfile actually resolves, not just whether an override exists — a
+  `pnpm.overrides` floor pinned one patch below the fix (e.g. `^3.15.0` against a fix in
+  `3.15.1`) leaves the vulnerable version installed while looking addressed. The
+  `Dependabot Updates` job may also fail outright on such an alert rather than opening
+  a PR, so a red job there is worth reading, not assuming.
 - **If a scan goes red:** CodeQL findings appear under **Security → Code scanning**;
   Scorecard details are in the public viewer. Treat a failing **read-only invariant** test
   as a release blocker — it means a write path was introduced (see


### PR DESCRIPTION
Documentation catch-up for this week's toolchain change, plus two operational traps worth writing down before they're forgotten.

## The thing worth documenting

The ts-jest → `@swc/jest` move (#62) changed a guarantee that a reader cannot infer from the scripts: **swc strips types without checking them**, so Jest alone no longer fails on a type error. Every doc still said "`npm test` is green" — describing a weaker guarantee than before without saying so.

`npm test` runs `typecheck` first precisely to close that gap, but `test:jest` does not, and a contributor reaching for it deserves to know what it skips.

## Changes

| File | What |
|---|---|
| `README.md` | Dev block lists `typecheck` and `test:jest`; short note on why the split exists |
| `CONTRIBUTING.md` | "Types are checked separately from tests" under project conventions; PR checklist now says `typecheck + Jest` |
| `docs/RELEASE.md` | Release checklist says why it must be `pnpm test`, not `test:jest` |

`docs/RELEASE.md` maintenance section also gains the two traps hit this week:

- **codeql-action bumps must merge together.** Dependabot raises `init`, `analyze` and `upload-sarif` separately, but `init` and `analyze` share `codeql.yml`. Merging one alone fails with `Loaded a configuration file for version 'X', but running version 'Y'` — and since `analyze (javascript-typescript)` is required, that blocks `main`. (Cost us #56/#58.)
- **An alert can outlive its fix.** A `pnpm.overrides` floor one patch below the patched version (`^3.15.0` against a fix in `3.15.1`) leaves the vulnerable version installed while looking addressed. Check `first_patched_version` against what the lockfile *resolves*. (Cost us alert #27 sitting open.)

## Verified, not asserted

The docs make a specific claim, so it was tested rather than assumed — a deliberate type error added to a test file:

| Command | Result |
|---|---|
| `npm run test:jest` | exit 0, "629 passed" — green on code that does not compile |
| `npm test` | exit 1, `error TS2322: Type 'string' is not assignable to type 'number'` |

Also confirmed every script named in the docs exists in `package.json`. No source changes; 85 suites / 629 tests still pass.

## Deliberately not changed

`Node.js 18+` in the README requirements. TypeScript 7 and swc are devDependencies, so the published package's `engines: >=18.0.0` is unaffected — bumping it would have wrongly narrowed the supported runtime for users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)