### PR TITLE
chore(ci): codeql-action v4.37.7, pnpm/action-setup v6.0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       # NOTE: no `registry-url` — it makes setup-node write an .npmrc with a
       # placeholder _authToken, which blocks npm's OIDC trusted-publishing exchange

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,7 +36,7 @@ jobs:
             --sarif --output semgrep.sarif || true
 
       - name: Upload findings to code scanning
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: semgrep.sarif
           category: semgrep


### PR DESCRIPTION
Supersedes Dependabot #68, #71 and #73.

## Why one PR

This is the trap we wrote into `docs/RELEASE.md` last week, recurring on schedule. Dependabot raised `init` (#73) and `analyze` (#71) as separate PRs, but both live in `codeql.yml` — merging either alone leaves the workflow mismatched:

```
Loaded a configuration file for version 'X', but running version 'Y'
```

Which is why both are red right now (`analyze (javascript-typescript)` FAILURE / CANCELLED), and since that check is required, each one blocks `main` on its own. They have to move in the same commit.

`#68` (pnpm/action-setup) is green and independent, but folding it in costs nothing and saves a full CI cycle — branch protection is strict, so serial merges mean re-running everything per PR.

## Changes

| Action | From | To | Files |
|---|---|---|---|
| `github/codeql-action/{init,analyze}` | v4.37.4 | v4.37.7 | `codeql.yml` |
| `github/codeql-action/upload-sarif` | v4.37.6 | v4.37.7 | `semgrep.yml`, `scorecard.yml` |
| `pnpm/action-setup` | v6.0.9 | v6.0.10 | `ci.yml` (×2), `publish.yml` |

`upload-sarif` had already moved to v4.37.6 via #72. Carrying it to v4.37.7 here means every `codeql-action` pin in the repo sits on **one** version instead of drifting across workflows — verified: a single SHA remains across all four references.

## Verification

Both SHAs resolved from the upstream annotated tags rather than trusted from the Dependabot diffs:

- `codeql-action` v4.37.7 → `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`
- `pnpm/action-setup` v6.0.10 → `0977fd99725f1db4007ccb2928dbb4e90d06cc86`

Workflow-only change; no source or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)