### PR TITLE
feat: HIPAA/GDPR catalogs, attack-chain coverage, MessagingChannel fix, README split

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 A Salesforce CLI (`sf`) plugin that runs a complete, **read-only** security audit against any Salesforce org, risk-scores it with an A–F grade, and turns the result into a report your security team (or your client's) can act on.
 
 - **88 read-only checks** across identity, access, data, code, integrations, monitoring, and Agentforce / GenAI
-- **Attack-chain correlation:** links individual findings into named, multi-step attack scenarios
-- **Compliance mapping:** every finding mapped to **source-verified** controls across 8 frameworks (OWASP, OWASP LLM Top 10, SOC 2, ISO/IEC 27001:2022, Security Benchmark for Salesforce, NZ Privacy Act, HISO 10029, NZISM)
+- **Attack-chain correlation:** links individual findings into named, multi-step attack scenarios — eleven modelled chains, plus an emergent pass for combinations nobody has named yet (see [Attack chains](#attack-chains))
+- **Compliance mapping:** every finding mapped to **source-verified** controls across 10 frameworks (OWASP, OWASP LLM Top 10, SOC 2, ISO/IEC 27001:2022, Security Benchmark for Salesforce, NZ Privacy Act, HISO 10029, NZISM, HIPAA Security Rule, GDPR)
 - **Outputs:** a technical `html` / `md` / `json` report, or a branded, client-ready **executive report** (print-to-PDF) with priorities, remediation roadmap, and a compliance coverage matrix
 - **History & diff:** archives each run and shows security-posture drift over time
 - **Free event baseline:** `sf audit events pull` captures the org's free daily `EventLogFile` logs to local disk before the 1-day retention window drops them — no Event Monitoring / Shield add-on needed
@@ -84,7 +84,7 @@ sf audit list
 | `--prepared-for` | (none) | Client name for the executive report cover line |
 | `--branding` | (none) | Path to a `report-branding.json` to override CloudCounsel defaults (executive format) |
 | `--top` | `5` | Number of executive priorities to highlight (executive format) |
-| `--frameworks` | `universal` | Compliance matrix scope (executive format): `universal` (OWASP/OWASP LLM/SOC 2/ISO 27001), `nz` (ISO/HISO/Privacy Act/NZISM), `all`, or a comma list (e.g. `owasp,owasp-llm,iso,nzism`) |
+| `--frameworks` | `universal` | Compliance matrix scope (executive format): `universal` (OWASP/OWASP LLM/SOC 2/ISO 27001), `nz` (ISO/HISO/Privacy Act/NZISM), `all`, or a comma list (e.g. `owasp,owasp-llm,iso,nzism`, or `hipaa` / `gdpr` for a US healthcare or EU/UK engagement) |
 | `--resolve-domains` | `false` | Makes **outbound DNS queries from this machine** to verify CSP trusted domains still resolve (flags unresolvable / parked domains as exfiltration channels). Off by default; a default run contacts **only the target org** and never reaches out to any other host. |
 
 ### Examples
@@ -133,7 +133,8 @@ sf audit security --target-org myOrg --format executive --branding ./report-bran
 
 Compliance controls are mapped from authoritative, version-pinned sources (OWASP Top 10:2021,
 OWASP Top 10 for LLM Applications 2025, AICPA TSC, ISO/IEC 27001:2022, the Security Benchmark for
-Salesforce, NZ Privacy Act, HISO 10029, NZISM). Only source-verified controls render. "No findings detected" is **not** an attestation of
+Salesforce, NZ Privacy Act, HISO 10029, NZISM, 45 CFR Part 164 Subpart C, Regulation (EU)
+2016/679). Only source-verified controls render. "No findings detected" is **not** an attestation of
 compliance (see the report's Scope & Liability section).
 
 The report file is written as `sf-audit-<orgId>-<timestamp>.<ext>` in the output directory (e.g. `sf-audit-00D000000000001-1711234567890.html`).
@@ -270,7 +271,7 @@ The audit runs **88 read-only checks**. Every finding is risk-rated (CRITICAL �
 | Agentforce Monitoring Coverage | Active agents running with no Event Monitoring capture and no Transaction Security policy (the monitoring gap in the ForcedLeak pattern); points at `sf audit events pull` |
 | Trusted URL Hygiene | Reviews the CSP trusted-sites allowlist for non-Salesforce domains that could be repurposed as exfiltration channels; with `--resolve-domains`, DNS-checks each for unresolvable or parked entries |
 
-Two named attack chains correlate these findings: **Prompt injection blast radius** (guest-reachable channel + over-privileged agent user + write-capable actions) and **ForcedLeak pattern** (active agents + a stale/unresolvable trusted URL + no event capture).
+Two of the named [attack chains](#attack-chains) correlate these findings specifically: **Prompt injection blast radius** (guest-reachable channel + over-privileged agent user + write-capable actions) and **ForcedLeak pattern** (active agents + a stale/unresolvable trusted URL + no event capture).
 
 The five agent-specific checks stay silent in orgs where Agentforce is not enabled (the GenAI objects do not exist, so the inventory records `not-enabled` and the dependent checks return nothing). Trusted URL Hygiene runs everywhere, since the CSP allowlist is an org-wide exfiltration surface regardless of Agentforce.
 
@@ -285,7 +286,7 @@ Advisory findings are surfaced as `INFO` and never inflate the health score.
 
 ## Compliance frameworks
 
-Findings are mapped to controls across eight security and privacy frameworks. The mapping is built on a **sourced control catalog** (each control carries its framework, **pinned version**, official title, and a citation) so a finding's compliance reference ties to an exact, defensible requirement rather than a bare tag.
+Findings are mapped to controls across ten security and privacy frameworks. The mapping is built on a **sourced control catalog** (each control carries its framework, **pinned version**, official title, and a citation) so a finding's compliance reference ties to an exact, defensible requirement rather than a bare tag.
 
 | Framework | Version | Notes |
 |-----------|---------|-------|
@@ -297,6 +298,8 @@ Findings are mapped to controls across eight security and privacy frameworks. Th
 | NZ Privacy Act | 2020 | Information Privacy Principles (IPP 5/9/12) |
 | HISO 10029 | 2022 | NZ Health Information Security Framework |
 | NZISM | v3.8 | NZ Information Security Manual |
+| HIPAA Security Rule | 45 CFR Part 164 Subpart C (2013 Omnibus) | Administrative (164.308) and technical (164.312) safeguards, with each implementation specification's **Required / Addressable** designation preserved. Maps the **operative** rule: the HHS NPRM of 2025-01-06 that would make encryption, MFA and segmentation mandatory is still proposed, not final |
+| GDPR | Regulation (EU) 2016/679 | Art. 5(1)(f), 25, 30, 32(1)(a)/(b)/(d), 33 and 44. Mapped at paragraph level, so a finding cites the specific obligation rather than "Article 32" at large |
 
 **Provenance gate.** Each catalogued control is marked `verified` only after its title/reference is confirmed against the authoritative source. **Controls that are not verified do not render** in the compliance matrix. Nothing ships as "compliant-to-clause" on unconfirmed data. The current verification status is tracked in [`docs/compliance/verification-worksheet.md`](docs/compliance/verification-worksheet.md).
 
@@ -304,12 +307,57 @@ Findings are mapped to controls across eight security and privacy frameworks. Th
 
 - `universal` *(default)*: OWASP, OWASP LLM Top 10, SOC 2, ISO 27001
 - `nz`: ISO 27001, HISO 10029, NZ Privacy Act, NZISM (for NZ health/government engagements)
-- `all`: every framework
-- a comma list of aliases, e.g. `owasp,owasp-llm,iso,nzism` (`owasp-llm` / `llm` selects the OWASP LLM Top 10)
+- `all`: every framework, including HIPAA and GDPR
+- a comma list of aliases, e.g. `owasp,owasp-llm,iso,nzism` (`owasp-llm` / `llm` selects the OWASP LLM Top 10, `hipaa` the HIPAA Security Rule, `gdpr` the GDPR articles)
+
+HIPAA and GDPR are not in either named pack, because scoping them is a jurisdictional decision rather than a default — select them explicitly for a US healthcare or EU/UK engagement:
+
+```bash
+# US healthcare engagement — HIPAA Security Rule safeguards alongside the universal set
+sf audit security --target-org myOrg --format executive --frameworks owasp,soc2,iso,hipaa
+
+# EU/UK engagement — GDPR security-of-processing obligations
+sf audit security --target-org myOrg --format executive --frameworks iso,gdpr
+```
 
 > **Not an attestation.** A control rendering "No findings detected" means this audit's checks surfaced no issues mapped to it. It is **not** a statement of compliance or certification. See [Scope & Liability](#scope--liability).
 
-**Further reading:** [Mapping Salesforce security to NZISM, the NZ Privacy Act and ISO 27001](https://www.softwareinsights.dev/posts/salesforce-security-nzism-nz-privacy-act/) and [Why Salesforce Health Cloud needs its own security review](https://www.softwareinsights.dev/posts/salesforce-health-cloud-security-review/). More in [Further reading](#further-reading).
+**Further reading:** [Mapping Salesforce security to NZISM, the NZ Privacy Act and ISO 27001](https://www.softwareinsights.dev/posts/salesforce-security-nzism-nz-privacy-act/) and [Why Salesforce Health Cloud needs its own security review](https://www.softwareinsights.dev/posts/salesforce-health-cloud-security-review/). More in [Further reading](docs/FURTHER-READING.md).
+
+## Attack chains
+
+A list of findings is not a risk assessment. Three MEDIUM findings that combine into an
+unauthenticated path to bulk data matter more than a lone HIGH that leads nowhere, and reading a
+report severity-by-severity hides exactly that. So every audit also correlates its findings into
+**attack chains**: the specific combinations that turn separate misconfigurations into a route from
+an attacker's entry point to a real outcome.
+
+Correlation runs in two passes. **Named chains** are hand-modelled scenarios — a known pattern, with
+its own narrative and remediation. Where no named chain explains a combination, an **emergent pass**
+reports the remaining entry-point → outcome pairs as lower-confidence "potential attack paths", so a
+novel combination is still surfaced rather than missed. Every chain lists the findings that form its
+steps, and remediating **any one step breaks the chain** — which is what makes this actionable
+rather than alarming.
+
+The eleven named chains:
+
+| Chain | Severity | Fires when |
+|-------|----------|-----------|
+| Unauthenticated bulk exfiltration | CRITICAL | A guest foothold combines with guest-reachable code execution, public external sharing, or a guest bulk-read surface — no login required. Reached over the site's Aura endpoint (`/s/sfsites/aura`, `aura.token=null`): `RecordUiController/ACTION$executeGraphQL` for record data, or `aura.ApexAction.execute` to invoke `@AuraEnabled` Apex that runs without sharing |
+| Active guest reconnaissance against an exposed data surface | CRITICAL | `AuraRequest` / `GraphQlQueryExecution` evidence shows guests probing from anonymizer IPs, or running `totalCount`-only GraphQL sweeps against `/s/sfsites/aura` to map what is readable, **and** the org exposes objects those guests can bulk-read. Reconnaissance against a confirmed surface — likely an incident already in progress |
+| Standard user to org takeover | CRITICAL | A low-trust or unauthenticated entry point combines with a privilege-escalation path: escalation permissions, Author Apex, shadow admins, delegated admin, Login-As, or a toxic permission combination |
+| Credential theft to external pivot | CRITICAL | Exposed secrets (hardcoded credentials, credentials in Custom Labels, debug logs, broad CORS) combine with an egress path — a named credential, remote site, or a self-provisioned connected app |
+| Prompt injection blast radius | CRITICAL | A guest-reachable Agentforce channel, an over-privileged agent run-as user, and write-capable agent actions are all present, so one injected prompt can read, alter, or destroy data across the agent's reach. Reached over the messaging host (`*.my.salesforce-scrt.com`, `/iamessage/api/v2/…`), **not** the site's Aura endpoint — the API's unauthenticated access-token flow needs only the org id and the deployment's `esDeveloperName`, both public in the widget's bootstrap |
+| ForcedLeak pattern | CRITICAL | Active agents + a stale or unresolvable CSP-trusted domain + no Event Monitoring capture. The Noma Security chain (Sept 2025): re-register the lapsed domain, inject an agent into sending data to it, and nothing records it |
+| SOQL injection to mass read | HIGH | Injectable dynamic SOQL combines with a bulk-readable data sink (broad sharing, unencrypted sensitive fields, public report folders, View All Data) |
+| MFA bypass to privileged compromise | HIGH | Weak MFA enforcement or trusted-IP MFA bypass coincides with highly-privileged accounts, so phishing or credential stuffing reaches an admin without a second factor |
+| Unmasked production PII in a weakly-controlled sandbox | HIGH | A sandbox holds populated PII fields — unmasked production data — while running weaker authentication or broader sharing than the org it was refreshed from. The data is real; only the protection is not |
+| Insider bulk export without monitoring | HIGH | Data is broadly readable internally, a profile or permission set can export it en masse, **and** no monitoring would record the export — the third element is what makes it unreconstructable afterwards |
+| Exploitable access with no detection coverage | MEDIUM | A real capability (unauthenticated foothold, privilege escalation, org takeover) exists while two or more of threat detection, Event Monitoring, Transaction Security and SIEM forwarding are absent. Adds no exposure — reports that existing exposure would go unobserved |
+
+Chains appear in the technical report and drive the executive report's priorities and remediation
+roadmap. A chain is only reported when **every** one of its ingredients is actually present: a clean
+org produces none.
 
 ## Scope & Liability
 
@@ -318,7 +366,7 @@ Findings are mapped to controls across eight security and privacy frameworks. Th
 **What this tool is not.** It is **not** a penetration test, a dynamic/runtime security test, or a source-code audit of managed-package internals. It does not exploit vulnerabilities, attempt privilege escalation, or guarantee detection of every misconfiguration. The Health Score and A–F grade are **prioritisation aids**, not certifications, and do not represent compliance with, or accreditation under, any standard (OWASP, SOC 2, ISO 27001, HIPAA, GDPR, or otherwise). Compliance-framework tags indicate *relevance* to a control area only.
 
 
-**Point-in-time.** Results reflect org configuration **at the moment the audit ran**. Configuration drift, new customisations, and platform changes can invalidate findings at any time. Re-run regularly (see [History & Diff](#history--diff)).
+**Point-in-time.** Results reflect org configuration **at the moment the audit ran**. Configuration drift, new customisations, and platform changes can invalidate findings at any time. Re-run regularly (see [History & Diff](docs/COMMANDS.md)).
 
 **Authorisation.** Run this tool only against orgs you own or are **explicitly authorised in writing** to assess. You are responsible for obtaining the necessary permissions and for handling generated reports (which may contain sensitive security configuration) in accordance with your organisation's data-handling and confidentiality obligations.
 
@@ -326,489 +374,53 @@ Findings are mapped to controls across eight security and privacy frameworks. Th
 
 ## Trust & verification
 
-Because this tool authenticates against production orgs, "is it safe to run?" deserves a verifiable answer, not just a claim. Here's how you can check for yourself:
+Because this tool authenticates against production orgs, "is it safe to run?" deserves a verifiable
+answer rather than a claim. Every guarantee below is something you can check yourself:
 
-- **Read-only, enforced in CI.** The "no writes to your org" promise is a passing test, not a footnote. `test/unit/invariants/readonly-invariant.test.ts` statically scans this package's entire source tree and fails the build if any jsforce mutation API, HTTP write verb, or bulk/composite write path ever appears. Every org request funnels through the core clients (`@cclabsnz/sf-core`, `src/api/*ClientImpl.ts`), which issue only SOQL queries, REST **GET**s, and Metadata reads. Each package in the monorepo runs the same guard against its own source, so nothing is covered by omission.
-- **Nothing phones home, enforced the same way.** `test/unit/invariants/network-egress.test.ts` fails the build on any third-party HTTP client, raw `node:http`/`https` use, telemetry/analytics/LLM endpoint, or websocket — and on any remote asset (`<script src>`, `<link href>`, `@import`) in a generated report. The only network destination is the org you authenticated against. Generated HTML reports are **fully self-contained**: webfonts are embedded as data URIs and Chart.js is inlined, so opening a report never calls out to a CDN — which matters, because reports carry sensitive findings and are often opened offline. Run both guards yourself:
+- **Read-only, enforced in CI** — a test statically fails the build if any write path appears in the source
+- **No network egress** — enforced the same way; reports are fully self-contained (fonts and Chart.js inlined)
+- **Signed provenance** — released from CI via npm trusted publishing (OIDC); `npm audit signatures` verifies the tarball against the public commit
+- **Independent scans** — CodeQL (`security-extended`, source *and* workflows), Semgrep, OpenSSF Scorecard, a dependency-review licence gate, `pnpm audit`, Dependabot, secret scanning with push protection, SHA-pinned Actions, and a CycloneDX SBOM per release
 
-  ```bash
-  pnpm --filter @cclabsnz/sf-audit test test/unit/invariants
-  ```
-- **What you install matches the public source.** Releases are published from GitHub Actions via [npm trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) with [build provenance](https://docs.npmjs.com/generating-provenance-statements) — no long-lived token, and the npm page shows a signed attestation linking the tarball to the exact public commit that built it. Verify it yourself:
-
-  ```bash
-  npm audit signatures   # reports "verified attestations" for @cclabsnz/sf-audit
-  ```
-
-- **Independent scans on every change.** Two static-analysis engines — [CodeQL](https://github.com/cclabsnz/sf-audit-plugin/security/code-scanning) (`security-extended`, of both the source **and** the CI workflows) and [Semgrep](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/semgrep.yml) (OWASP Top 10 + security-audit rulesets) — an [OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/cclabsnz/sf-audit-plugin) supply-chain review, a PR **dependency-review** gate (vulnerabilities **and** a copyleft-license policy), and a `pnpm audit` gate — plus Dependabot, and GitHub secret scanning with push protection. All GitHub Actions are pinned to commit SHAs. Each release ships a CycloneDX **SBOM**.
-- **Regulated-environment readiness.** The above give reviewers a paper trail for procurement: SBOM per release, an enforced dependency **license policy**, signed provenance, and independent SAST/supply-chain scans.
-- **Least privilege & disclosure.** See [PERMISSIONS.md](PERMISSIONS.md) for the minimal access it needs and [SECURITY.md](SECURITY.md) for private vulnerability reporting.
-
-### What third-party scanners flag, and why
-
-[Socket](https://socket.dev/npm/package/@cclabsnz/sf-audit) raises two **supply-chain risk** alerts against this package. Neither is a vulnerability — both are behavioural heuristics — and rather than suppress them quietly, here is exactly what triggers each and how you can confirm it. The triage is committed as [`socket.yml`](../../socket.yml).
-
-| Alert | What triggers it | Why it is expected |
-| --- | --- | --- |
-| **Filesystem access** | `node:fs` reads and writes | It is a CLI that writes your audit reports (HTML/MD/JSON) to disk and reads local inputs: report-branding overrides, event-log baselines under `~/.sf/audit-history`, and its own history archive. Every path is one you pass on the command line or the tool's own dot-directory. |
-| **URL strings** | `https://` literals in the shipped code | These are inert citation links rendered as `<a href>` in reports — OWASP, NZISM, the NZ Privacy Act, Te Whatu Ora and CIS-style benchmark references cited by compliance findings. They are never fetched. |
-
-Check the second one yourself — this lists every URL in the published build:
+Run the guards yourself:
 
 ```bash
-npm pack @cclabsnz/sf-audit && tar xzf cclabsnz-sf-audit-*.tgz
-grep -rhoE 'https?://[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}[^"'"'"'`,;) ]*' package/lib | sort -u
+npm test test/unit/invariants
+npm audit signatures
 ```
 
-As of v1.6.1 that prints seven results, every one a standards-body or documentation link:
-
-```
-https://docs.securitybenchmark.org/controls-at-a-glance.html
-https://genai.owasp.org/llm-top-10/
-https://nzism.gcsb.govt.nz/ism-document
-https://owasp.org/Top10/2021/
-https://privacy.org.nz/privacy-act-2020/privacy-principles/
-https://www.legislation.govt.nz/act/public/2020/0031/latest/LMS23342.html
-https://www.tewhatuora.govt.nz/health-services-and-programmes/cyber-hub/cyber-standards
-```
-
-No CDN, telemetry, or analytics endpoints — and the network-egress invariant above fails the build if one is ever added.
+Full detail, including why Socket raises two behavioural alerts against this package and how to
+confirm each: **[docs/TRUST.md](docs/TRUST.md)**. Least-privilege access is in
+[PERMISSIONS.md](PERMISSIONS.md); vulnerability reporting in [SECURITY.md](SECURITY.md).
 
 ## Scoring
 
-Each finding is assigned a risk level with a corresponding weight:
-
-| Risk Level | Default Weight |
-|------------|---------------|
-| CRITICAL | 10 |
-| HIGH | 7 |
-| MEDIUM | 4 |
-| LOW | 1 |
-| INFO | 0 |
-
-The health score is calculated as `100 - (total weight / max possible weight) * 100`, capped at 0.
-
-The audit produces a **Health Score** (0–100) and a **Grade** (A–F):
-
-| Grade | Criteria |
-|-------|---------|
-| A | Score ≥ 85, no HIGH findings |
-| B | Score ≥ 70, ≤ 1 HIGH finding |
-| C | Score ≥ 55, ≤ 3 HIGH findings |
-| D | Score ≥ 40, no CRITICAL findings |
-| F | Score < 40 or any CRITICAL finding |
-
-### Custom Scoring Config
-
-All weights and grade thresholds are configurable: no recompile needed. This is useful when your org has a different risk appetite (e.g. you want to penalise hardcoded credentials more heavily, or set stricter grade thresholds).
-
-**Step 1:** Copy the sample config as your starting point:
-
-```bash
-cp config/scoring.sample.json my-scoring.json
-```
-
-**Step 2:** Edit the values. All three sections (`riskScores`, `checkWeights`, `gradeThresholds`) are optional: omit any section to keep the defaults.
-
-```json
-{
-  "riskScores": {
-    "CRITICAL": 10,
-    "HIGH": 7,
-    "MEDIUM": 4,
-    "LOW": 1,
-    "INFO": 0
-  },
-  "checkWeights": {
-    "hardcoded-credentials": 10,
-    "guest-user-access": 10,
-    "users-and-admins": 10,
-    "apex-sharing": 7
-  },
-  "gradeThresholds": {
-    "A": { "minScore": 90, "maxHigh": 0 },
-    "B": { "minScore": 75, "maxHigh": 1 },
-    "C": { "minScore": 60, "maxHigh": 3 },
-    "D": { "minScore": 40, "maxCritical": 0 },
-    "F": {}
-  }
-}
-```
-
-The full list of valid `checkWeights` keys (one per check) is in [`config/scoring.sample.json`](config/scoring.sample.json).
-
-**Step 3:** Pass it when running the audit:
-
-```bash
-sf audit security --target-org myOrg --scoring-config ./my-scoring.json
-```
-
-Your config is deep-merged with the defaults, so you only need to include the values you want to change.
-
-## History & Diff
-
-Every `sf audit security` run automatically archives a JSON copy of the report to:
-
-```
-~/.sf/audit-history/{orgId}/sf-audit-{orgId}-{timestamp}.json
-```
-
-No configuration needed: archiving happens silently after each run.
-
-### View Audit History
-
-Show how your org's security posture has changed across multiple runs:
-
-```bash
-sf audit history --target-org myOrg
-```
-
-Prints a terminal table with score trends and writes an HTML timeline to the current directory.
-
-**Flags:**
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--target-org` | Org alias or username | required |
-| `--reports-dir` | Custom directory containing archived reports | `~/.sf/audit-history/{orgId}` |
-| `--output` | Directory to write the HTML timeline | `.` (cwd) |
-| `--limit` | Maximum number of most-recent runs to show | all |
-
-**Example output:**
-
-```
-Audit History: My Org (00D000000000001)
-────────────────────────────────────────────────────────────────────────────────
-  #   Date                  Score   Grade   CRIT   HIGH    MED    LOW   Δ Score
-────────────────────────────────────────────────────────────────────────────────
-   1  2026-03-23 15:10       64      D          1      5      8      3        —
-   2  2026-04-09 11:22       81      B          0      2      5      3      +17
-────────────────────────────────────────────────────────────────────────────────
-  Trend: ▲ +17 over 2 audits   Best: 81 (2026-04-09 11:22)   Worst: 64 (2026-03-23 15:10)
-```
-
-### Diff Two Reports
-
-Compare any two audit JSON files to see exactly what changed:
-
-```bash
-sf audit diff baseline.json current.json
-```
-
-Writes an HTML and JSON diff report to the current directory.
-
-**Flags:**
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--output` | Directory to write diff reports | `.` (cwd) |
-| `--format` | Comma-separated formats: `html`, `json` | `html,json` |
-
-**Example output:**
-
-```
-Diff report written: ./sf-audit-diff-00D000000000001-...-vs-....html
-Diff report written: ./sf-audit-diff-00D000000000001-...-vs-....json
-
-─────────────────────────────
-  Diff Summary
-─────────────────────────────
-  Score delta     +17
-  Grade        D → B
-  New               0
-  Resolved          1
-─────────────────────────────
-```
-
-## Free event baseline
-
-Salesforce's free tier exposes **Daily-interval `EventLogFile` logs** (login, API, and error
-activity) on Enterprise/Unlimited/Performance editions and Developer Edition — *without* the paid
-Event Monitoring / Shield add-on. The catch: on the free tier those logs are retained for only
-**~1 day**. Miss a day and that day's activity is gone.
-
-`sf audit events pull` captures them to local disk before they expire, so a daily run builds a
-rolling local baseline you own:
-
-```bash
-sf audit events pull --target-org myOrg
-```
-
-It queries whatever daily event types the org actually exposes, downloads each log's CSV body, and
-saves it to `~/.sf/event-baseline/{orgId}/{EventType}/{LogDate}-{Id}.csv`, plus a per-run manifest.
-It is **read-only** (GET only) and **idempotent**: any log already on disk is skipped, so it is safe
-to run repeatedly. Run it once a day from cron or a scheduled GitHub Action and you beat the 1-day
-retention window with a growing archive — no add-on required.
-
-```bash
-# Daily cron entry (07:15) — capture yesterday's logs
-15 7 * * *  sf audit events pull --target-org myOrg >> ~/.sf/event-baseline/pull.log 2>&1
-```
-
-**Flags:**
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--target-org` | Org alias or username | required |
-| `--since` | Days of `LogDate` to request (`LAST_N_DAYS` window) | `1` |
-| `--types` | Restrict to specific EventTypes, comma-separated (e.g. `Login,ApiTotalUsage`) | *(all available)* |
-| `--output` / `-o` | Base directory to store logs under | `~/.sf/event-baseline` |
-
-```bash
-# Backfill the last 3 days (each still subject to the org's retention)
-sf audit events pull --target-org myOrg --since 3
-
-# Only pull login and API-usage logs
-sf audit events pull --target-org myOrg --types Login,ApiTotalUsage
-
-# Store under a project-local directory instead of ~/.sf
-sf audit events pull --target-org myOrg --output ./event-baseline
-```
-
-> Reading `EventLogFile` requires the **View Event Log Files** permission on the running user (this
-> is in addition to the minimum read-only audit permission set). If it is missing, or the edition
-> does not expose free daily logs, the command exits cleanly with an explanation rather than failing.
-
-**Example output:**
-
-```
-Pulling free EventLogFile logs for org: My Org (00D000000000001)
-
-─────────────────────────────
-  Event Baseline Pull
-─────────────────────────────
-  Found           7
-  Downloaded      7
-  Skipped         0  (already saved)
-  Total bytes  48213
-─────────────────────────────
-  Saved to: ~/.sf/event-baseline/00D000000000001
-  Manifest: ~/.sf/event-baseline/00D000000000001/_manifests/manifest-...-....json
-```
-
-### Analyzing the captured logs
-
-`events pull` is the collection half. To triage those `EventLogFile` CSVs for exploit and
-abuse patterns, use the companion CLI **[sfelf-triage](https://github.com/cclabsnz/sfelf-triage)**.
-It reads downloaded EventLogFile CSVs and emits a per-IP verdict
-(`BENIGN_SCANNER | SUSPICIOUS | LIKELY_ABUSE`), answering *"is this guest/community IP a
-vulnerability scanner or a real threat?"* — with **zero network egress** and no org connection.
-
-sfelf-triage reads this plugin's `~/.sf/event-baseline/<orgId>` layout directly, so the two
-tools chain with no glue:
-
-```bash
-sf audit events pull --target-org myOrg          # capture (this plugin)
-sfelf-triage analyze ~/.sf/event-baseline/<orgId>  # triage (companion)
-```
-
-See the [sfelf-triage README](https://github.com/cclabsnz/sfelf-triage#readme) for install and usage.
-
-## Forensic timeline
-
-Salesforce splits one actor's activity across many event types, and each carries a different
-subset of identifying fields — so no single log answers *"what did this actor do"*. Filtering by
-IP finds the requests but misses every SOQL execution, because the query log has no `CLIENT_IP`
-column at all. Filtering by user finds everything the *guest* user did, which on a community is
-everyone.
-
-`sf audit timeline` correlates a seed across every captured event type and writes a defensible
-timeline:
-
-```bash
-sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed ip:203.0.113.50
-```
-
-It runs **entirely offline** against captures written by `sf audit events pull` — no org
-connection is opened, so it still works long after the org's retention window has expired or its
-credentials have been revoked. The org id is inferred from the capture directory when only one
-org has been captured.
-
-### What it will not do
-
-Cross-event correlation is easy to get confidently wrong, and a wrong answer here reads as
-evidence. Two rules are enforced and both are visible in the output:
-
-- **A blank field is never a join key.** A blank `REQUEST_ID` used as a key stops identifying
-  anything and starts matching every other row whose value is also blank — quietly attributing
-  strangers' sessions to your actor.
-- **A shared identity is not expanded.** A community guest user can stand for hundreds of
-  distinct visitors. Expanding through it would present the whole crowd's activity as one
-  actor's, so it is refused by default and the refusal is reported with its evidence:
-
-  ```
-  Expansion refused: userId 005xx0000000000 is shared by 1371 distinct addresses
-    (threshold 8). Override with --allow-shared-identity.
-  ```
-
-Every output also leads with what was actually captured, because *"no rows matched"* means two
-entirely different things — the actor did nothing, or nobody captured the hour they did it in:
-
-```
-Window — coverage INCOMPLETE
-  captured   AuraRequest, ListViewEvent
-  MISSING    LightningInteraction (not-in-core-set)
-  MISSING    GuestUserAnomalyEventStore (storage-disabled)
-
-No activity in captured sources. Coverage incomplete — 2 sources missing.
-```
-
-**Flags:**
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--window` | When to look — see below | required |
-| `--seed` | Typed and repeatable: `ip:` `user:` `session:` `request:` `login:` `transaction:` `event:` | *(whole window)* |
-| `--org-id` | Which captured org to read | *(inferred when unambiguous)* |
-| `--input` | Capture base directory | `~/.sf/event-baseline` |
-| `--allow-shared-identity` | Expand through identities shared by many actors | `false` |
-| `--max-cardinality` | Distinct-actor ceiling above which a key is not expanded | `8` |
-| `--format` | Comma-separated: `csv,json,md` | all three |
-| `--output` | Directory to write into | `.` |
-
-**Finding your way in.** Two things you do not have to know up front. Omit `--seed` and you get
-the whole window, uncorrelated — which is where you look to find something worth seeding on.
-Ask for a window that was never captured and the error lists the days that *were*:
-
-```
-No captures for 2026-07-01 under ~/.sf/event-baseline/00Dxx0000000000EAA.
-
-Captured days for this org:
-  2026-08-01   11 event type(s), whole day
-  2026-08-02   14 event type(s), whole day
-
-Try:  --window 2026-08-02
-```
-
-**Saying when.** `--window` takes whichever form is nearest to hand — you should not have to
-compose an ISO 8601 interval while an incident is running:
-
-| You type | You get |
-|---|---|
-| `yesterday` | the whole of yesterday, UTC |
-| `today` | midnight UTC until now |
-| `2h` · `90m` | the last two hours; the last ninety minutes |
-| `2026-08-02` | that whole day — the shape the free tier captures in |
-| `2026-08-02T04:17Z` | the hour containing that instant, for a timestamp pasted from an alert |
-| `2026-08-02T04:00Z/PT1H` | an exact interval, start and duration |
-| `2026-08-02T04:00Z/2026-08-02T06:00Z` | an exact interval, start and end |
-
-Times are UTC, because every capture is stored in UTC — a bare timestamp with no zone is read
-that way rather than as local time. A window has to fall inside one UTC day; one that crosses
-midnight is refused, and the error names the two runs that would cover it.
-
-```bash
-# Follow one address across every captured event type
-sf audit timeline --window yesterday --seed ip:203.0.113.50
-
-# Start from a request and walk outward, including its Apex cascade
-sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed request:abc123
-
-# Several orgs captured — name the one to read
-sf audit timeline --org-id 00Dxx0000000000EAA --window 2026-08-02T04:00Z/PT2H --seed user:005xx000000000
-
-# Machine-readable only, into an evidence directory
-sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed ip:203.0.113.50 \
-  --format json --output ./evidence/incident-2026-08-02
-```
-
-**Outputs:**
-
-| File | Contents |
-|------|----------|
-| `timeline.csv` | The correlated rows, one schema across all sources, chronological |
-| `timeline.json` | The same rows plus the provenance — seeds, every key expanded through, and every refusal |
-| `summary.md` | Narrative: coverage, per-type counts, what tied each row in, refusals, and whether records left |
-
-Each row records **which join key tied it in**, so attribution is checkable rather than asserted.
-The `rows_processed` and `records_returned` columns are populated only from Real-Time Event
-objects — no `EventLogFile` type records them — and when none were captured the summary says the
-question is unanswerable rather than going quiet, since silence there reads as *"nothing left"*.
-
-### Checking a claim against its control group
-
-When a seed's rows share an identity with many other people — a community guest user, a shared
-integration account — *"this actor did X"* needs something to be checked against. Otherwise the
-claim is unfalsifiable: nobody can tell your 15 rows from the other 600 behind the same user.
-
-The refusal message already gives you the denominator:
-
-```
-Expansion refused: userId 005xx000000000 is shared by 1371 distinct addresses (threshold 8).
-```
-
-To see the peer set itself, run the command a second time seeded on that identity, with expansion
-allowed:
-
-```bash
-# 1. The claim — narrow, seeded on something that identifies one actor
-sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed request:REQ000000 \
-  --output ./evidence/actor
-
-# 2. The control — everyone behind the identity those rows share
-sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed user:005xx000000000 \
-  --allow-shared-identity --output ./evidence/peers
-```
-
-Both use the same schema, so they concatenate and diff directly:
-
-```bash
-# How much of the identity's activity is actually your actor?
-# (tail -n +2 skips the header row, so these are data rows)
-echo "actor:   $(tail -n +2 ./evidence/actor/timeline.csv | wc -l)"
-echo "control: $(tail -n +2 ./evidence/peers/timeline.csv | wc -l)"
-```
-
-An actor accounting for 15 of 603 rows — 2.5%, and separable by request id — is a different
-finding from one accounting for 580 of 603. The second command is what lets a reviewer tell
-which they are looking at, rather than taking the first on trust.
-
-> `sf audit timeline` adds **no checks** and does not affect the security grade. It is an
-> investigation command, not a `SecurityCheck`.
-
-## Connected-app least-privilege
-
-Connected-app over-privilege was at the centre of the 2025-2026 wave of Salesforce data-theft
-via OAuth: apps authorized with more scope than they use, and integration users with far more
-object access than the app ever touches. The static checks (`connected-apps`, `connected-app-scope`,
-`connected-app-inactivity`) tell you what was *granted*. `sf audit apps` tells you what is actually
-*used*, so it can point at the specific access to remove.
-
-```bash
-sf audit apps --target-org myOrg --since 7
-```
-
-It reads the `RestApi` `EventLogFile` to see which objects each connected app touched, compares that
-against the objects its run-as user can reach, and reports the over-grant per object and read/write
-bit — plus a generated least-privilege permission set granting exactly what was observed. App IDs are
-resolved to human-readable names (`AppMenuItem` / `ConnectedApplication` / a bundled standard-app
-catalog / `LoginHistory` correlation), and anything unresolved is flagged loudly rather than hidden.
-
-It is **read-only**: the suggested permission set is emitted as data, never deployed.
-
-**Honest bounds.** `RestApi` attributes roughly half of API traffic to a connected app (the rest is
-UI-API / session traffic), so *used* is a lower bound. Findings carry the observation window and
-attribution rate, and revoke recommendations are suppressed below a soak window and for apps used by
-many interactive users. Reading `EventLogFile` needs the **View Event Log Files** permission (the same
-one `events pull` uses).
-
-**Flags:**
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--target-org` | Org alias or username | required |
-| `--since` | Days of `RestApi` log to analyze | `7` |
-| `--from` | Read `RestApi` CSVs from a local `events pull` baseline dir instead of downloading | *(download)* |
-| `--soak` | Minimum window (days) before asserting revoke recommendations | `7` |
-| `--format` | `table` / `json` / `md` | `table` |
-
-```bash
-# Reuse an events-pull baseline instead of downloading again
-sf audit apps --target-org myOrg --from ~/.sf/event-baseline/00Dxxx
-
-# Machine-readable output
-sf audit apps --target-org myOrg --format json
-```
+Each finding carries a risk weight (CRITICAL 10, HIGH 7, MEDIUM 4, LOW 1, INFO 0). The health score is
+`100 - (total weight / max possible weight) * 100`, capped at 0, and maps to an A–F grade — A needs
+≥ 85 with no HIGH findings; any CRITICAL is an F.
+
+All weights and grade thresholds are configurable without recompiling, via
+`--scoring-config ./my-scoring.json`. Start from [`config/scoring.sample.json`](config/scoring.sample.json),
+which lists every valid `checkWeights` key; your config is deep-merged with the defaults, so include
+only what you want to change.
+
+Grade bands, the full config shape and worked examples: **[docs/SCORING.md](docs/SCORING.md)**.
+
+## Other commands
+
+Beyond the audit itself, the plugin ships four commands. Each is documented in
+**[docs/COMMANDS.md](docs/COMMANDS.md)**.
+
+| Command | What it does |
+|---------|--------------|
+| `sf audit history` / `sf audit diff` | Every run auto-archives to `~/.sf/audit-history/{orgId}`. Show posture drift across runs as a table plus an HTML timeline, or diff any two report JSONs |
+| `sf audit events pull` | Capture the org's **free** daily `EventLogFile` logs to local disk before the ~1-day retention window drops them — no Event Monitoring / Shield add-on needed. Idempotent, safe to cron |
+| `sf audit timeline` | Reconstruct one actor's activity across every captured event type, entirely offline. Refuses to expand a shared identity or join on a blank field, and always reports capture coverage first |
+| `sf audit apps` | Read the `RestApi` event log to compare what each connected app actually *uses* against what its run-as user is *granted*, and emit a suggested least-privilege permission set |
+
+To triage captured logs for abuse patterns, pair `events pull` with the companion CLI
+**[sfelf-triage](https://github.com/cclabsnz/sfelf-triage)**, which reads this plugin's
+`~/.sf/event-baseline/<orgId>` layout directly.
 
 ## Requirements
 
@@ -835,44 +447,12 @@ Maintainers: see **[docs/RELEASE.md](docs/RELEASE.md)** for the release checklis
 
 ## Further reading
 
-Deep dives on this tool and the topics it checks, from our engineering blog **[softwareinsights.dev](https://www.softwareinsights.dev)**.
+Deep dives on this tool and the topics it checks, from our engineering blog
+**[softwareinsights.dev](https://www.softwareinsights.dev)** — including how sf-audit works, the free
+Event Monitoring baseline, guest-user exposure grading, the delivery-team access model, Agentforce
+hardening after ForcedLeak, and the NZ compliance context.
 
-**How the commands work:**
-
-- [How sf-audit works — checks, attack chains, and compliance mapping](https://www.softwareinsights.dev/posts/sf-audit-61-checks-attack-chains-compliance-mapping/) — the design walkthrough behind `sf audit security`
-- [Free Salesforce Event Monitoring: a baseline from EventLogFile without Shield](https://www.softwareinsights.dev/posts/salesforce-free-event-monitoring-eventlogfile-baseline/) — why [`sf audit events pull`](#free-event-baseline) exists and how to cron it
-- [Which connected apps use less than they're granted? Ask your own logs](https://www.softwareinsights.dev/posts/salesforce-connected-app-least-privilege-granted-vs-used/) — the granted-vs-used method behind [`sf audit apps`](#connected-app-least-privilege)
-- [Scanner or breach? Triage EventLogFile in one command](https://www.softwareinsights.dev/posts/salesforce-eventlogfile-guest-traffic-triage-scanner-or-breach/) — pairing an `events pull` baseline with the [sfelf-triage](https://github.com/cclabsnz/sfelf-triage) companion
-- [Salesforce guest user exposure, graded by real reachability](https://www.softwareinsights.dev/posts/sf-audit-guest-user-exposure-reachability/) — the UI-API reachability tiering behind the [guest checks](#guest--external-facing-access)
-- [sf-audit vs sf-cli-security-audit](https://www.softwareinsights.dev/posts/sf-audit-vs-sf-cli-security-audit/) — how this plugin differs from a configurable policy engine, and when to reach for each
-
-**The access model the privilege checks encode** — the reasoning behind [Users, Permissions & Privilege](#users-permissions--privilege):
-
-- [Why your developers don't need Modify All Data](https://www.softwareinsights.dev/posts/salesforce-developers-modify-all-data-what-they-need-instead/) — part 1 of a four-part series on delivery-team access; feeds Users & Admins and Privileged Access & Shadow Admins
-- [The access model: tiers and roles](https://www.softwareinsights.dev/posts/salesforce-delivery-team-access-model-tiers-and-roles/) — the tiering that Separation of Duties and Privilege Escalation Permissions test against
-- [Sizing the model to your team](https://www.softwareinsights.dev/posts/salesforce-access-model-sizing-internal-vs-external-admin-teams/) — internal vs external admins, and what the model costs to run
-- [Deployable permission sets](https://www.softwareinsights.dev/posts/salesforce-delivery-team-deployable-permission-sets/) — the metadata and the CI identity, which the Integration / Service Accounts check inventories
-
-**Platform changes the checks track:**
-
-- [Hardening Agentforce against prompt injection (post-ForcedLeak)](https://www.softwareinsights.dev/posts/salesforce-agentforce-forcedleak-prompt-injection-hardening/) — feeds the Agentforce / GenAI checks
-- [Audit your Agentforce footprint: every agent, agent user, and permission](https://www.softwareinsights.dev/posts/salesforce-agentforce-footprint-audit/) — the manual SOQL behind Agent Inventory
-- [Agentforce agent user least privilege](https://www.softwareinsights.dev/posts/salesforce-agentforce-agent-user-least-privilege/) — feeds the Agent User Privilege check
-- [Salesforce MFA enforcement: the revised 2026 dates](https://www.softwareinsights.dev/posts/salesforce-mfa-enforcement-paused-revised-dates-2026/) — feeds the MFA checks
-- [The MFA enforcement admin guide](https://www.softwareinsights.dev/posts/salesforce-mfa-enforcement-2026-admin-guide/) — what the MFA Enforcement / Registration / Method Strength checks are measuring against
-- [MFA lockout recovery and break-glass accounts](https://www.softwareinsights.dev/posts/salesforce-mfa-lockout-recovery-break-glass-accounts/) — the operational side of the MFA and High Assurance Session checks
-- [OAuth username-password (ROPC) flow retirement in Winter '27](https://www.softwareinsights.dev/posts/salesforce-oauth-username-password-flow-retirement-winter-27/) — feeds the SSO Enforcement and Connected App OAuth Scopes checks
-- [Email change verification retirement and Authorized Email Domains](https://www.softwareinsights.dev/posts/salesforce-email-change-verification-retirement-authorized-email-domains/) — feeds the Email Security check
-- [Summer '26: SAML retirement & Apex secure-by-default](https://www.softwareinsights.dev/posts/salesforce-summer-26-saml-retirement-apex-secure-by-default/) — feeds the SSO / Apex checks
-- [Salesforce security enforcement in 2026 — every change and date](https://www.softwareinsights.dev/posts/salesforce-security-enforcement-2026-complete-guide/) — the overall posture this tool measures
-- [Report-export step-up enforcement: known issues](https://www.softwareinsights.dev/posts/salesforce-transaction-security-policy-report-export-known-issues/) — feeds the data-export / transaction-security checks
-
-**Compliance and NZ context** — background for the [framework mappings](#compliance-frameworks):
-
-- [Mapping Salesforce security to NZISM, the NZ Privacy Act and ISO 27001](https://www.softwareinsights.dev/posts/salesforce-security-nzism-nz-privacy-act/)
-- [Data sovereignty for New Zealand Salesforce orgs](https://www.softwareinsights.dev/posts/salesforce-data-sovereignty-new-zealand/) — residency vs sovereignty, and why the `nz` framework pack exists
-- [IPP 3A indirect collection notices](https://www.softwareinsights.dev/posts/salesforce-nz-privacy-ipp3a-indirect-collection-notice/) — feeds the NZ Privacy Act control mappings
-- [Why Salesforce Health Cloud needs its own security review](https://www.softwareinsights.dev/posts/salesforce-health-cloud-security-review/) — the HISO 10029 context
+Full annotated list: **[docs/FURTHER-READING.md](docs/FURTHER-READING.md)**.
 
 ## Commercial support
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,382 @@
+# Command reference
+
+Deep dives for the commands beyond `sf audit security`. The [README](../README.md) covers the audit
+itself, what it checks, the compliance mapping and the attack chains.
+
+- [Free event baseline](#free-event-baseline) — `sf audit events pull`
+- [Forensic timeline](#forensic-timeline) — `sf audit timeline`
+- [History and diff](#history--diff) — `sf audit history`, `sf audit diff`
+- [Connected-app least-privilege](#connected-app-least-privilege) — `sf audit apps`
+
+---
+
+# Free event baseline
+
+Salesforce's free tier exposes **Daily-interval `EventLogFile` logs** (login, API, and error
+activity) on Enterprise/Unlimited/Performance editions and Developer Edition — *without* the paid
+Event Monitoring / Shield add-on. The catch: on the free tier those logs are retained for only
+**~1 day**. Miss a day and that day's activity is gone.
+
+`sf audit events pull` captures them to local disk before they expire, so a daily run builds a
+rolling local baseline you own:
+
+```bash
+sf audit events pull --target-org myOrg
+```
+
+It queries whatever daily event types the org actually exposes, downloads each log's CSV body, and
+saves it to `~/.sf/event-baseline/{orgId}/{EventType}/{LogDate}-{Id}.csv`, plus a per-run manifest.
+It is **read-only** (GET only) and **idempotent**: any log already on disk is skipped, so it is safe
+to run repeatedly. Run it once a day from cron or a scheduled GitHub Action and you beat the 1-day
+retention window with a growing archive — no add-on required.
+
+```bash
+# Daily cron entry (07:15) — capture yesterday's logs
+15 7 * * *  sf audit events pull --target-org myOrg >> ~/.sf/event-baseline/pull.log 2>&1
+```
+
+**Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--target-org` | Org alias or username | required |
+| `--since` | Days of `LogDate` to request (`LAST_N_DAYS` window) | `1` |
+| `--types` | Restrict to specific EventTypes, comma-separated (e.g. `Login,ApiTotalUsage`) | *(all available)* |
+| `--output` / `-o` | Base directory to store logs under | `~/.sf/event-baseline` |
+
+```bash
+# Backfill the last 3 days (each still subject to the org's retention)
+sf audit events pull --target-org myOrg --since 3
+
+# Only pull login and API-usage logs
+sf audit events pull --target-org myOrg --types Login,ApiTotalUsage
+
+# Store under a project-local directory instead of ~/.sf
+sf audit events pull --target-org myOrg --output ./event-baseline
+```
+
+> Reading `EventLogFile` requires the **View Event Log Files** permission on the running user (this
+> is in addition to the minimum read-only audit permission set). If it is missing, or the edition
+> does not expose free daily logs, the command exits cleanly with an explanation rather than failing.
+
+**Example output:**
+
+```
+Pulling free EventLogFile logs for org: My Org (00D000000000001)
+
+─────────────────────────────
+  Event Baseline Pull
+─────────────────────────────
+  Found           7
+  Downloaded      7
+  Skipped         0  (already saved)
+  Total bytes  48213
+─────────────────────────────
+  Saved to: ~/.sf/event-baseline/00D000000000001
+  Manifest: ~/.sf/event-baseline/00D000000000001/_manifests/manifest-...-....json
+```
+
+## Analyzing the captured logs
+
+`events pull` is the collection half. To triage those `EventLogFile` CSVs for exploit and
+abuse patterns, use the companion CLI **[sfelf-triage](https://github.com/cclabsnz/sfelf-triage)**.
+It reads downloaded EventLogFile CSVs and emits a per-IP verdict
+(`BENIGN_SCANNER | SUSPICIOUS | LIKELY_ABUSE`), answering *"is this guest/community IP a
+vulnerability scanner or a real threat?"* — with **zero network egress** and no org connection.
+
+sfelf-triage reads this plugin's `~/.sf/event-baseline/<orgId>` layout directly, so the two
+tools chain with no glue:
+
+```bash
+sf audit events pull --target-org myOrg          # capture (this plugin)
+sfelf-triage analyze ~/.sf/event-baseline/<orgId>  # triage (companion)
+```
+
+See the [sfelf-triage README](https://github.com/cclabsnz/sfelf-triage#readme) for install and usage.
+
+---
+
+# Forensic timeline
+
+Salesforce splits one actor's activity across many event types, and each carries a different
+subset of identifying fields — so no single log answers *"what did this actor do"*. Filtering by
+IP finds the requests but misses every SOQL execution, because the query log has no `CLIENT_IP`
+column at all. Filtering by user finds everything the *guest* user did, which on a community is
+everyone.
+
+`sf audit timeline` correlates a seed across every captured event type and writes a defensible
+timeline:
+
+```bash
+sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed ip:203.0.113.50
+```
+
+It runs **entirely offline** against captures written by `sf audit events pull` — no org
+connection is opened, so it still works long after the org's retention window has expired or its
+credentials have been revoked. The org id is inferred from the capture directory when only one
+org has been captured.
+
+## What it will not do
+
+Cross-event correlation is easy to get confidently wrong, and a wrong answer here reads as
+evidence. Two rules are enforced and both are visible in the output:
+
+- **A blank field is never a join key.** A blank `REQUEST_ID` used as a key stops identifying
+  anything and starts matching every other row whose value is also blank — quietly attributing
+  strangers' sessions to your actor.
+- **A shared identity is not expanded.** A community guest user can stand for hundreds of
+  distinct visitors. Expanding through it would present the whole crowd's activity as one
+  actor's, so it is refused by default and the refusal is reported with its evidence:
+
+  ```
+  Expansion refused: userId 005xx0000000000 is shared by 1371 distinct addresses
+    (threshold 8). Override with --allow-shared-identity.
+  ```
+
+Every output also leads with what was actually captured, because *"no rows matched"* means two
+entirely different things — the actor did nothing, or nobody captured the hour they did it in:
+
+```
+Window — coverage INCOMPLETE
+  captured   AuraRequest, ListViewEvent
+  MISSING    LightningInteraction (not-in-core-set)
+  MISSING    GuestUserAnomalyEventStore (storage-disabled)
+
+No activity in captured sources. Coverage incomplete — 2 sources missing.
+```
+
+**Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--window` | When to look — see below | required |
+| `--seed` | Typed and repeatable: `ip:` `user:` `session:` `request:` `login:` `transaction:` `event:` | *(whole window)* |
+| `--org-id` | Which captured org to read | *(inferred when unambiguous)* |
+| `--input` | Capture base directory | `~/.sf/event-baseline` |
+| `--allow-shared-identity` | Expand through identities shared by many actors | `false` |
+| `--max-cardinality` | Distinct-actor ceiling above which a key is not expanded | `8` |
+| `--format` | Comma-separated: `csv,json,md` | all three |
+| `--output` | Directory to write into | `.` |
+
+**Finding your way in.** Two things you do not have to know up front. Omit `--seed` and you get
+the whole window, uncorrelated — which is where you look to find something worth seeding on.
+Ask for a window that was never captured and the error lists the days that *were*:
+
+```
+No captures for 2026-07-01 under ~/.sf/event-baseline/00Dxx0000000000EAA.
+
+Captured days for this org:
+  2026-08-01   11 event type(s), whole day
+  2026-08-02   14 event type(s), whole day
+
+Try:  --window 2026-08-02
+```
+
+**Saying when.** `--window` takes whichever form is nearest to hand — you should not have to
+compose an ISO 8601 interval while an incident is running:
+
+| You type | You get |
+|---|---|
+| `yesterday` | the whole of yesterday, UTC |
+| `today` | midnight UTC until now |
+| `2h` · `90m` | the last two hours; the last ninety minutes |
+| `2026-08-02` | that whole day — the shape the free tier captures in |
+| `2026-08-02T04:17Z` | the hour containing that instant, for a timestamp pasted from an alert |
+| `2026-08-02T04:00Z/PT1H` | an exact interval, start and duration |
+| `2026-08-02T04:00Z/2026-08-02T06:00Z` | an exact interval, start and end |
+
+Times are UTC, because every capture is stored in UTC — a bare timestamp with no zone is read
+that way rather than as local time. A window has to fall inside one UTC day; one that crosses
+midnight is refused, and the error names the two runs that would cover it.
+
+```bash
+# Follow one address across every captured event type
+sf audit timeline --window yesterday --seed ip:203.0.113.50
+
+# Start from a request and walk outward, including its Apex cascade
+sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed request:abc123
+
+# Several orgs captured — name the one to read
+sf audit timeline --org-id 00Dxx0000000000EAA --window 2026-08-02T04:00Z/PT2H --seed user:005xx000000000
+
+# Machine-readable only, into an evidence directory
+sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed ip:203.0.113.50 \
+  --format json --output ./evidence/incident-2026-08-02
+```
+
+**Outputs:**
+
+| File | Contents |
+|------|----------|
+| `timeline.csv` | The correlated rows, one schema across all sources, chronological |
+| `timeline.json` | The same rows plus the provenance — seeds, every key expanded through, and every refusal |
+| `summary.md` | Narrative: coverage, per-type counts, what tied each row in, refusals, and whether records left |
+
+Each row records **which join key tied it in**, so attribution is checkable rather than asserted.
+The `rows_processed` and `records_returned` columns are populated only from Real-Time Event
+objects — no `EventLogFile` type records them — and when none were captured the summary says the
+question is unanswerable rather than going quiet, since silence there reads as *"nothing left"*.
+
+## Checking a claim against its control group
+
+When a seed's rows share an identity with many other people — a community guest user, a shared
+integration account — *"this actor did X"* needs something to be checked against. Otherwise the
+claim is unfalsifiable: nobody can tell your 15 rows from the other 600 behind the same user.
+
+The refusal message already gives you the denominator:
+
+```
+Expansion refused: userId 005xx000000000 is shared by 1371 distinct addresses (threshold 8).
+```
+
+To see the peer set itself, run the command a second time seeded on that identity, with expansion
+allowed:
+
+```bash
+# 1. The claim — narrow, seeded on something that identifies one actor
+sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed request:REQ000000 \
+  --output ./evidence/actor
+
+# 2. The control — everyone behind the identity those rows share
+sf audit timeline --window 2026-08-02T04:00Z/PT1H --seed user:005xx000000000 \
+  --allow-shared-identity --output ./evidence/peers
+```
+
+Both use the same schema, so they concatenate and diff directly:
+
+```bash
+# How much of the identity's activity is actually your actor?
+# (tail -n +2 skips the header row, so these are data rows)
+echo "actor:   $(tail -n +2 ./evidence/actor/timeline.csv | wc -l)"
+echo "control: $(tail -n +2 ./evidence/peers/timeline.csv | wc -l)"
+```
+
+An actor accounting for 15 of 603 rows — 2.5%, and separable by request id — is a different
+finding from one accounting for 580 of 603. The second command is what lets a reviewer tell
+which they are looking at, rather than taking the first on trust.
+
+> `sf audit timeline` adds **no checks** and does not affect the security grade. It is an
+> investigation command, not a `SecurityCheck`.
+
+---
+
+# History & Diff
+
+Every `sf audit security` run automatically archives a JSON copy of the report to:
+
+```
+~/.sf/audit-history/{orgId}/sf-audit-{orgId}-{timestamp}.json
+```
+
+No configuration needed: archiving happens silently after each run.
+
+## View Audit History
+
+Show how your org's security posture has changed across multiple runs:
+
+```bash
+sf audit history --target-org myOrg
+```
+
+Prints a terminal table with score trends and writes an HTML timeline to the current directory.
+
+**Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--target-org` | Org alias or username | required |
+| `--reports-dir` | Custom directory containing archived reports | `~/.sf/audit-history/{orgId}` |
+| `--output` | Directory to write the HTML timeline | `.` (cwd) |
+| `--limit` | Maximum number of most-recent runs to show | all |
+
+**Example output:**
+
+```
+Audit History: My Org (00D000000000001)
+────────────────────────────────────────────────────────────────────────────────
+  #   Date                  Score   Grade   CRIT   HIGH    MED    LOW   Δ Score
+────────────────────────────────────────────────────────────────────────────────
+   1  2026-03-23 15:10       64      D          1      5      8      3        —
+   2  2026-04-09 11:22       81      B          0      2      5      3      +17
+────────────────────────────────────────────────────────────────────────────────
+  Trend: ▲ +17 over 2 audits   Best: 81 (2026-04-09 11:22)   Worst: 64 (2026-03-23 15:10)
+```
+
+## Diff Two Reports
+
+Compare any two audit JSON files to see exactly what changed:
+
+```bash
+sf audit diff baseline.json current.json
+```
+
+Writes an HTML and JSON diff report to the current directory.
+
+**Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--output` | Directory to write diff reports | `.` (cwd) |
+| `--format` | Comma-separated formats: `html`, `json` | `html,json` |
+
+**Example output:**
+
+```
+Diff report written: ./sf-audit-diff-00D000000000001-...-vs-....html
+Diff report written: ./sf-audit-diff-00D000000000001-...-vs-....json
+
+─────────────────────────────
+  Diff Summary
+─────────────────────────────
+  Score delta     +17
+  Grade        D → B
+  New               0
+  Resolved          1
+─────────────────────────────
+```
+
+---
+
+# Connected-app least-privilege
+
+Connected-app over-privilege was at the centre of the 2025-2026 wave of Salesforce data-theft
+via OAuth: apps authorized with more scope than they use, and integration users with far more
+object access than the app ever touches. The static checks (`connected-apps`, `connected-app-scope`,
+`connected-app-inactivity`) tell you what was *granted*. `sf audit apps` tells you what is actually
+*used*, so it can point at the specific access to remove.
+
+```bash
+sf audit apps --target-org myOrg --since 7
+```
+
+It reads the `RestApi` `EventLogFile` to see which objects each connected app touched, compares that
+against the objects its run-as user can reach, and reports the over-grant per object and read/write
+bit — plus a generated least-privilege permission set granting exactly what was observed. App IDs are
+resolved to human-readable names (`AppMenuItem` / `ConnectedApplication` / a bundled standard-app
+catalog / `LoginHistory` correlation), and anything unresolved is flagged loudly rather than hidden.
+
+It is **read-only**: the suggested permission set is emitted as data, never deployed.
+
+**Honest bounds.** `RestApi` attributes roughly half of API traffic to a connected app (the rest is
+UI-API / session traffic), so *used* is a lower bound. Findings carry the observation window and
+attribution rate, and revoke recommendations are suppressed below a soak window and for apps used by
+many interactive users. Reading `EventLogFile` needs the **View Event Log Files** permission (the same
+one `events pull` uses).
+
+**Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--target-org` | Org alias or username | required |
+| `--since` | Days of `RestApi` log to analyze | `7` |
+| `--from` | Read `RestApi` CSVs from a local `events pull` baseline dir instead of downloading | *(download)* |
+| `--soak` | Minimum window (days) before asserting revoke recommendations | `7` |
+| `--format` | `table` / `json` / `md` | `table` |
+
+```bash
+# Reuse an events-pull baseline instead of downloading again
+sf audit apps --target-org myOrg --from ~/.sf/event-baseline/00Dxxx
+
+# Machine-readable output
+sf audit apps --target-org myOrg --format json
+```

--- a/docs/FURTHER-READING.md
+++ b/docs/FURTHER-READING.md
@@ -1,0 +1,40 @@
+# Further reading
+
+Deep dives on this tool and the topics it checks, from our engineering blog **[softwareinsights.dev](https://www.softwareinsights.dev)**.
+
+**How the commands work:**
+
+- [How sf-audit works — checks, attack chains, and compliance mapping](https://www.softwareinsights.dev/posts/sf-audit-61-checks-attack-chains-compliance-mapping/) — the design walkthrough behind `sf audit security`
+- [Free Salesforce Event Monitoring: a baseline from EventLogFile without Shield](https://www.softwareinsights.dev/posts/salesforce-free-event-monitoring-eventlogfile-baseline/) — why [`sf audit events pull`](#free-event-baseline) exists and how to cron it
+- [Which connected apps use less than they're granted? Ask your own logs](https://www.softwareinsights.dev/posts/salesforce-connected-app-least-privilege-granted-vs-used/) — the granted-vs-used method behind [`sf audit apps`](#connected-app-least-privilege)
+- [Scanner or breach? Triage EventLogFile in one command](https://www.softwareinsights.dev/posts/salesforce-eventlogfile-guest-traffic-triage-scanner-or-breach/) — pairing an `events pull` baseline with the [sfelf-triage](https://github.com/cclabsnz/sfelf-triage) companion
+- [Salesforce guest user exposure, graded by real reachability](https://www.softwareinsights.dev/posts/sf-audit-guest-user-exposure-reachability/) — the UI-API reachability tiering behind the [guest checks](#guest--external-facing-access)
+- [sf-audit vs sf-cli-security-audit](https://www.softwareinsights.dev/posts/sf-audit-vs-sf-cli-security-audit/) — how this plugin differs from a configurable policy engine, and when to reach for each
+
+**The access model the privilege checks encode** — the reasoning behind [Users, Permissions & Privilege](#users-permissions--privilege):
+
+- [Why your developers don't need Modify All Data](https://www.softwareinsights.dev/posts/salesforce-developers-modify-all-data-what-they-need-instead/) — part 1 of a four-part series on delivery-team access; feeds Users & Admins and Privileged Access & Shadow Admins
+- [The access model: tiers and roles](https://www.softwareinsights.dev/posts/salesforce-delivery-team-access-model-tiers-and-roles/) — the tiering that Separation of Duties and Privilege Escalation Permissions test against
+- [Sizing the model to your team](https://www.softwareinsights.dev/posts/salesforce-access-model-sizing-internal-vs-external-admin-teams/) — internal vs external admins, and what the model costs to run
+- [Deployable permission sets](https://www.softwareinsights.dev/posts/salesforce-delivery-team-deployable-permission-sets/) — the metadata and the CI identity, which the Integration / Service Accounts check inventories
+
+**Platform changes the checks track:**
+
+- [Hardening Agentforce against prompt injection (post-ForcedLeak)](https://www.softwareinsights.dev/posts/salesforce-agentforce-forcedleak-prompt-injection-hardening/) — feeds the Agentforce / GenAI checks
+- [Audit your Agentforce footprint: every agent, agent user, and permission](https://www.softwareinsights.dev/posts/salesforce-agentforce-footprint-audit/) — the manual SOQL behind Agent Inventory
+- [Agentforce agent user least privilege](https://www.softwareinsights.dev/posts/salesforce-agentforce-agent-user-least-privilege/) — feeds the Agent User Privilege check
+- [Salesforce MFA enforcement: the revised 2026 dates](https://www.softwareinsights.dev/posts/salesforce-mfa-enforcement-paused-revised-dates-2026/) — feeds the MFA checks
+- [The MFA enforcement admin guide](https://www.softwareinsights.dev/posts/salesforce-mfa-enforcement-2026-admin-guide/) — what the MFA Enforcement / Registration / Method Strength checks are measuring against
+- [MFA lockout recovery and break-glass accounts](https://www.softwareinsights.dev/posts/salesforce-mfa-lockout-recovery-break-glass-accounts/) — the operational side of the MFA and High Assurance Session checks
+- [OAuth username-password (ROPC) flow retirement in Winter '27](https://www.softwareinsights.dev/posts/salesforce-oauth-username-password-flow-retirement-winter-27/) — feeds the SSO Enforcement and Connected App OAuth Scopes checks
+- [Email change verification retirement and Authorized Email Domains](https://www.softwareinsights.dev/posts/salesforce-email-change-verification-retirement-authorized-email-domains/) — feeds the Email Security check
+- [Summer '26: SAML retirement & Apex secure-by-default](https://www.softwareinsights.dev/posts/salesforce-summer-26-saml-retirement-apex-secure-by-default/) — feeds the SSO / Apex checks
+- [Salesforce security enforcement in 2026 — every change and date](https://www.softwareinsights.dev/posts/salesforce-security-enforcement-2026-complete-guide/) — the overall posture this tool measures
+- [Report-export step-up enforcement: known issues](https://www.softwareinsights.dev/posts/salesforce-transaction-security-policy-report-export-known-issues/) — feeds the data-export / transaction-security checks
+
+**Compliance and NZ context** — background for the [framework mappings](#compliance-frameworks):
+
+- [Mapping Salesforce security to NZISM, the NZ Privacy Act and ISO 27001](https://www.softwareinsights.dev/posts/salesforce-security-nzism-nz-privacy-act/)
+- [Data sovereignty for New Zealand Salesforce orgs](https://www.softwareinsights.dev/posts/salesforce-data-sovereignty-new-zealand/) — residency vs sovereignty, and why the `nz` framework pack exists
+- [IPP 3A indirect collection notices](https://www.softwareinsights.dev/posts/salesforce-nz-privacy-ipp3a-indirect-collection-notice/) — feeds the NZ Privacy Act control mappings
+- [Why Salesforce Health Cloud needs its own security review](https://www.softwareinsights.dev/posts/salesforce-health-cloud-security-review/) — the HISO 10029 context

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -1,0 +1,71 @@
+# Scoring
+
+
+Each finding is assigned a risk level with a corresponding weight:
+
+| Risk Level | Default Weight |
+|------------|---------------|
+| CRITICAL | 10 |
+| HIGH | 7 |
+| MEDIUM | 4 |
+| LOW | 1 |
+| INFO | 0 |
+
+The health score is calculated as `100 - (total weight / max possible weight) * 100`, capped at 0.
+
+The audit produces a **Health Score** (0–100) and a **Grade** (A–F):
+
+| Grade | Criteria |
+|-------|---------|
+| A | Score ≥ 85, no HIGH findings |
+| B | Score ≥ 70, ≤ 1 HIGH finding |
+| C | Score ≥ 55, ≤ 3 HIGH findings |
+| D | Score ≥ 40, no CRITICAL findings |
+| F | Score < 40 or any CRITICAL finding |
+
+## Custom Scoring Config
+
+All weights and grade thresholds are configurable: no recompile needed. This is useful when your org has a different risk appetite (e.g. you want to penalise hardcoded credentials more heavily, or set stricter grade thresholds).
+
+**Step 1:** Copy the sample config as your starting point:
+
+```bash
+cp config/scoring.sample.json my-scoring.json
+```
+
+**Step 2:** Edit the values. All three sections (`riskScores`, `checkWeights`, `gradeThresholds`) are optional: omit any section to keep the defaults.
+
+```json
+{
+  "riskScores": {
+    "CRITICAL": 10,
+    "HIGH": 7,
+    "MEDIUM": 4,
+    "LOW": 1,
+    "INFO": 0
+  },
+  "checkWeights": {
+    "hardcoded-credentials": 10,
+    "guest-user-access": 10,
+    "users-and-admins": 10,
+    "apex-sharing": 7
+  },
+  "gradeThresholds": {
+    "A": { "minScore": 90, "maxHigh": 0 },
+    "B": { "minScore": 75, "maxHigh": 1 },
+    "C": { "minScore": 60, "maxHigh": 3 },
+    "D": { "minScore": 40, "maxCritical": 0 },
+    "F": {}
+  }
+}
+```
+
+The full list of valid `checkWeights` keys (one per check) is in [`config/scoring.sample.json`](../config/scoring.sample.json).
+
+**Step 3:** Pass it when running the audit:
+
+```bash
+sf audit security --target-org myOrg --scoring-config ./my-scoring.json
+```
+
+Your config is deep-merged with the defaults, so you only need to include the values you want to change.

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -1,0 +1,57 @@
+# Trust & verification
+
+Because this tool authenticates against production orgs, "is it safe to run?" deserves a verifiable answer, not just a claim. Here's how you can check for yourself:
+
+- **Read-only, enforced in CI.** The "no writes to your org" promise is a passing test, not a footnote. `test/unit/invariants/readonly-invariant.test.ts` statically scans this package's entire source tree and fails the build if any jsforce mutation API, HTTP write verb, or bulk/composite write path ever appears. Every org request funnels through the client implementations in [`@cclabsnz/sf-core`](https://www.npmjs.com/package/@cclabsnz/sf-core) (`SoqlClientImpl`, `ToolingClientImpl`, `RestClientImpl`, `MetadataClientImpl`), which issue only SOQL queries, REST **GET**s, and Metadata reads. `src/lib/wire.ts` is the single place a `Connection` is turned into those clients, so there is no side path to the org.
+- **Nothing phones home, enforced the same way.** `test/unit/invariants/network-egress.test.ts` fails the build on any third-party HTTP client, raw `node:http`/`https` use, telemetry/analytics/LLM endpoint, or websocket — and on any remote asset (`<script src>`, `<link href>`, `@import`) in a generated report. The only network destination is the org you authenticated against. Generated HTML reports are **fully self-contained**: webfonts are embedded as data URIs and Chart.js is inlined, so opening a report never calls out to a CDN — which matters, because reports carry sensitive findings and are often opened offline. Run both guards yourself:
+
+  ```bash
+  npm test test/unit/invariants
+  ```
+- **What you install matches the public source.** Releases are published from GitHub Actions via [npm trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) with [build provenance](https://docs.npmjs.com/generating-provenance-statements) — no long-lived token, and the npm page shows a signed attestation linking the tarball to the exact public commit that built it. Verify it yourself:
+
+  ```bash
+  npm audit signatures   # reports "verified attestations" for @cclabsnz/sf-audit
+  ```
+
+- **Independent scans on every change.** Two static-analysis engines — [CodeQL](https://github.com/cclabsnz/sf-audit-plugin/security/code-scanning) (`security-extended`, of both the source **and** the CI workflows) and [Semgrep](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/semgrep.yml) (OWASP Top 10 + security-audit rulesets) — an [OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/cclabsnz/sf-audit-plugin) supply-chain review, a PR **dependency-review** gate (vulnerabilities **and** a copyleft-license policy), and a `pnpm audit` gate — plus Dependabot, and GitHub secret scanning with push protection. All GitHub Actions are pinned to commit SHAs. Each release ships a CycloneDX **SBOM**.
+- **Regulated-environment readiness.** The above give reviewers a paper trail for procurement: SBOM per release, an enforced dependency **license policy**, signed provenance, and independent SAST/supply-chain scans.
+- **Least privilege & disclosure.** See [PERMISSIONS.md](../PERMISSIONS.md) for the minimal access it needs and [SECURITY.md](../SECURITY.md) for private vulnerability reporting.
+
+## What third-party scanners flag, and why
+
+[Socket](https://socket.dev/npm/package/@cclabsnz/sf-audit) raises two **supply-chain risk** alerts against this package. Neither is a vulnerability — both are behavioural heuristics — and rather than suppress them quietly, here is exactly what triggers each and how you can confirm it. The triage is committed as [`socket.yml`](../socket.yml).
+
+| Alert | What triggers it | Why it is expected |
+| --- | --- | --- |
+| **Filesystem access** | `node:fs` reads and writes | It is a CLI that writes your audit reports (HTML/MD/JSON) to disk and reads local inputs: report-branding overrides, event-log baselines under `~/.sf/audit-history`, and its own history archive. Every path is one you pass on the command line or the tool's own dot-directory. |
+| **URL strings** | `https://` literals in the shipped code | These are inert citation links rendered as `<a href>` in reports — OWASP, NZISM, the NZ Privacy Act, Te Whatu Ora and CIS-style benchmark references cited by compliance findings. They are never fetched. |
+
+Check the second one yourself — this lists every URL in the published build:
+
+```bash
+npm pack @cclabsnz/sf-audit && tar xzf cclabsnz-sf-audit-*.tgz
+grep -rhoE 'https?://[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}[^"'"'"'`,;) ]*' package/lib | sort -u
+```
+
+As of v1.8.2 that prints ten results. Seven are the standards-body citations rendered as `<a href>` in compliance findings:
+
+```
+https://docs.securitybenchmark.org/controls-at-a-glance.html
+https://genai.owasp.org/llm-top-10/
+https://nzism.gcsb.govt.nz/ism-document
+https://owasp.org/Top10/2021/
+https://privacy.org.nz/privacy-act-2020/privacy-principles/
+https://www.legislation.govt.nz/act/public/2020/0031/latest/LMS23342.html
+https://www.tewhatuora.govt.nz/health-services-and-programmes/cyber-hub/cyber-standards
+```
+
+The other three are this project's own attribution links, printed in report footers and CLI output rather than fetched:
+
+```
+https://cloudcounsel.co.nz                      # report footer / branding default
+https://github.com/cclabsnz/sf-audit-plugin     # report footer
+https://softwareinsights.dev                    # further-reading pointer in CLI output
+```
+
+No CDN, telemetry, or analytics endpoints — and the network-egress invariant above fails the build if one is ever added.

--- a/docs/compliance/verification-worksheet.md
+++ b/docs/compliance/verification-worksheet.md
@@ -2,7 +2,7 @@
 
 Controls marked verified have been checked against an authoritative source. Unverified controls stay excluded from rendered reports (provenance gate).
 
-Total controls: 89 · Verified: 89
+Total controls: 119 · Verified: 119
 
 ## OWASP — OWASP Top 10:2021 (9/9 verified)
 
@@ -17,6 +17,15 @@ Total controls: 89 · Verified: 89
 | [x] | OWASP-A08 | Software and Data Integrity Failures | OWASP Top 10:2021 A08 |
 | [x] | OWASP-A09 | Security Logging and Monitoring Failures | OWASP Top 10:2021 A09 |
 | [x] | OWASP-A10 | Server-Side Request Forgery (SSRF) | OWASP Top 10:2021 A10 |
+
+## OWASP_LLM — OWASP Top 10 for LLM Applications 2025 (4/4 verified)
+
+| ✓ | id | title | sourceRef |
+|---|---|---|---|
+| [x] | LLM01 | Prompt Injection | OWASP Top 10 for LLM Applications 2025, LLM01 |
+| [x] | LLM02 | Sensitive Information Disclosure | OWASP Top 10 for LLM Applications 2025, LLM02 |
+| [x] | LLM05 | Improper Output Handling | OWASP Top 10 for LLM Applications 2025, LLM05 |
+| [x] | LLM06 | Excessive Agency | OWASP Top 10 for LLM Applications 2025, LLM06 |
 
 ## SOC2 — AICPA TSC 2017 (Common Criteria) (11/11 verified)
 
@@ -127,4 +136,57 @@ Total controls: 89 · Verified: 89
 | [x] | NZISM-SW | Software and application security | NZISM v3.8, Ch.14 Software Security |
 | [x] | NZISM-NET | Network security and gateways | NZISM v3.8, Ch.18 Network Security / Ch.19 Gateway Security |
 | [x] | NZISM-CONFIG | System hardening and configuration | NZISM v3.8, Ch.12 Product Security (configuration and patching) |
+
+## HIPAA — 45 CFR Part 164 Subpart C (HIPAA Security Rule, 2013 Omnibus) (18/18 verified)
+
+Standard headings, implementation-specification names and each spec's Required/Addressable
+designation verified 2026-08 against the codified text of 45 CFR 164.308 and 164.312.
+
+**Version watch.** The HHS NPRM of 2025-01-06 would remove the Required/Addressable distinction and
+make encryption, MFA and network segmentation mandatory. As of 2026-08 it remains **proposed**, so
+this catalog maps the operative 2013 Omnibus rule. When the final rule publishes, re-pin `version`
+and re-verify every row rather than amending in place.
+
+Physical safeguards (164.310), contingency planning (164.308(a)(7)) and documentation (164.316) are
+out of scope for a read-only org-configuration review and are deliberately absent.
+
+| ✓ | id | title | sourceRef |
+|---|---|---|---|
+| [x] | HIPAA-164.308(a)(1)(ii)(A) | Risk analysis (Required) | 45 CFR 164.308(a)(1)(ii)(A) |
+| [x] | HIPAA-164.308(a)(1)(ii)(B) | Risk management (Required) | 45 CFR 164.308(a)(1)(ii)(B) |
+| [x] | HIPAA-164.308(a)(1)(ii)(D) | Information system activity review (Required) | 45 CFR 164.308(a)(1)(ii)(D) |
+| [x] | HIPAA-164.308(a)(3) | Workforce security | 45 CFR 164.308(a)(3) |
+| [x] | HIPAA-164.308(a)(4) | Information access management | 45 CFR 164.308(a)(4) |
+| [x] | HIPAA-164.308(a)(5)(ii)(C) | Log-in monitoring (Addressable) | 45 CFR 164.308(a)(5)(ii)(C) |
+| [x] | HIPAA-164.308(a)(5)(ii)(D) | Password management (Addressable) | 45 CFR 164.308(a)(5)(ii)(D) |
+| [x] | HIPAA-164.308(a)(6) | Security incident procedures | 45 CFR 164.308(a)(6) |
+| [x] | HIPAA-164.308(a)(8) | Evaluation | 45 CFR 164.308(a)(8) |
+| [x] | HIPAA-164.312(a)(1) | Access control | 45 CFR 164.312(a)(1) |
+| [x] | HIPAA-164.312(a)(2)(i) | Unique user identification (Required) | 45 CFR 164.312(a)(2)(i) |
+| [x] | HIPAA-164.312(a)(2)(iii) | Automatic logoff (Addressable) | 45 CFR 164.312(a)(2)(iii) |
+| [x] | HIPAA-164.312(a)(2)(iv) | Encryption and decryption (Addressable) | 45 CFR 164.312(a)(2)(iv) |
+| [x] | HIPAA-164.312(b) | Audit controls | 45 CFR 164.312(b) |
+| [x] | HIPAA-164.312(c)(1) | Integrity | 45 CFR 164.312(c)(1) |
+| [x] | HIPAA-164.312(d) | Person or entity authentication | 45 CFR 164.312(d) |
+| [x] | HIPAA-164.312(e)(1) | Transmission security | 45 CFR 164.312(e)(1) |
+| [x] | HIPAA-164.312(e)(2)(ii) | Encryption in transmission (Addressable) | 45 CFR 164.312(e)(2)(ii) |
+
+## GDPR — Regulation (EU) 2016/679 (8/8 verified)
+
+Article headings and the quoted text of Art. 5(1)(f), 25 and 32(1)(a)-(d) verified 2026-08 against
+the consolidated regulation text; OJ L 119, 4.5.2016 is the canonical reference. Where an obligation
+is a paragraph rather than a whole article, the id names the paragraph so a finding cites the
+specific duty. Articles on lawful basis, data-subject rights, DPIAs (Art. 35) and
+controller/processor contracts are out of scope for a configuration review and deliberately absent.
+
+| ✓ | id | title | sourceRef |
+|---|---|---|---|
+| [x] | GDPR-Art5(1)(f) | Integrity and confidentiality | Regulation (EU) 2016/679, Art. 5(1)(f) |
+| [x] | GDPR-Art25 | Data protection by design and by default | Regulation (EU) 2016/679, Art. 25(1)-(2) |
+| [x] | GDPR-Art30 | Records of processing activities | Regulation (EU) 2016/679, Art. 30(1) |
+| [x] | GDPR-Art32(1)(a) | Pseudonymisation and encryption of personal data | Regulation (EU) 2016/679, Art. 32(1)(a) |
+| [x] | GDPR-Art32(1)(b) | Ongoing confidentiality, integrity, availability and resilience | Regulation (EU) 2016/679, Art. 32(1)(b) |
+| [x] | GDPR-Art32(1)(d) | Regular testing and evaluation of security measures | Regulation (EU) 2016/679, Art. 32(1)(d) |
+| [x] | GDPR-Art33 | Notification of a personal data breach to the supervisory authority | Regulation (EU) 2016/679, Art. 33(1) |
+| [x] | GDPR-Art44 | General principle for transfers | Regulation (EU) 2016/679, Art. 44 |
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@types/jest": "^30",
     "@types/node": "^26",
     "jest": "^30",
-    "ts-node": "^10.9.2",
     "typescript": "^7.0.2"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,6 @@ importers:
       jest:
         specifier: ^30
         version: 30.4.2(@types/node@26.2.0)(ts-node@10.9.2(@swc/core@1.15.47)(@types/node@26.2.0)(typescript@7.0.2))
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.15.47)(@types/node@26.2.0)(typescript@7.0.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -2684,6 +2681,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -2960,6 +2958,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
 
   '@jsforce/jsforce-node@3.10.19':
     dependencies:
@@ -3188,13 +3187,17 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tsconfig/node10@1.0.12': {}
+  '@tsconfig/node10@1.0.12':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -3395,8 +3398,10 @@ snapshots:
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
+    optional: true
 
-  acorn@8.16.0: {}
+  acorn@8.16.0:
+    optional: true
 
   ajv@8.20.0:
     dependencies:
@@ -3436,7 +3441,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -3656,7 +3662,8 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3690,7 +3697,8 @@ snapshots:
 
   detect-newline@3.1.0: {}
 
-  diff@4.0.4: {}
+  diff@4.0.4:
+    optional: true
 
   dot-case@3.0.4:
     dependencies:
@@ -4478,7 +4486,8 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   makeerror@1.0.12:
     dependencies:
@@ -4959,6 +4968,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.47
+    optional: true
 
   ts-retry-promise@0.8.1: {}
 
@@ -5046,7 +5056,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -5132,7 +5143,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/src/chains/CapabilityRegistry.ts
+++ b/src/chains/CapabilityRegistry.ts
@@ -9,8 +9,12 @@ export interface CapabilityEntry {
 
 /**
  * The full attack model lives here: finding id → attacker capabilities it grants.
- * Keep this the single source of truth so the ~75 checks stay untouched.
- * Every key MUST correspond to a finding id some check can emit (see registry-integrity test).
+ * Keep this the single source of truth so the 88 checks stay untouched.
+ *
+ * Every key MUST correspond to a finding id some check can actually emit, and every id referenced
+ * by a named chain must be emittable too — a typo in either place fails silently (a key that
+ * matches nothing simply never grants, and a chain ingredient that matches nothing means the chain
+ * never fires). `test/unit/chains/registryIntegrity.test.ts` enforces both directions.
  */
 export const CAPABILITY_REGISTRY: Record<string, CapabilityEntry> = {
   // Guest / unauthenticated foothold
@@ -66,6 +70,35 @@ export const CAPABILITY_REGISTRY: Record<string, CapabilityEntry> = {
   'login-access-policy-login-as-enabled': { grants: ['priv-esc', 'data-read-bulk'] },
   // External federation an attacker could ride in on
   'auth-providers-social':             { grants: ['low-trust-authenticated'] },
+
+  // Toxic permission combinations held by one user. Capabilities follow each combo's own stated
+  // outcome — see COMBOS in SeparationOfDutiesCheck, where the ids are defined.
+  'separation-of-duties-self-escalation':       { grants: ['priv-esc', 'org-takeover'] },
+  'separation-of-duties-identity-takeover':     { grants: ['priv-esc', 'org-takeover'] },
+  'separation-of-duties-grant-self-data':       { grants: ['priv-esc', 'data-read-bulk'] },
+  'separation-of-duties-code-and-data':         { grants: ['code-exec', 'data-read-bulk', 'data-write'] },
+  'separation-of-duties-external-exfil-channel':{ grants: ['external-egress', 'data-read-bulk'] },
+  'separation-of-duties-tamper-and-cover':      { grants: ['data-write', 'data-read-bulk'] },
+  // Admin-equivalent users who are not on the System Administrator profile: the same reach as
+  // 'users-super-admin-combo', which is why it grants the same capability.
+  'privileged-access-shadow-admins':            { grants: ['org-takeover', 'priv-esc'] },
+  // Flows running in system context without sharing enforcement — the Flow analogue of
+  // 'portal-exposed-apex-without-sharing'. Screen flows need a user to drive them, so they do not
+  // grant the unattended write that an autolaunched flow does.
+  'flows-autolaunched-without-sharing':         { grants: ['code-exec', 'data-read', 'data-write'] },
+  'flows-screen-without-sharing':               { grants: ['code-exec', 'data-read'] },
+  // Sharing rules granting All Internal Users — bulk read for any authenticated employee. Internal
+  // by definition, so this grants no 'low-trust-authenticated' entry point of its own.
+  'public-group-sharing-exposure':              { grants: ['data-read-bulk'] },
+  // Report folders any authenticated user can view.
+  'report-folder-access-public':                { grants: ['data-read'] },
+  // "Secure guest user record access" not enforced: guest-owned records can defeat a Private OWD.
+  // The policy gap widens guest visibility rather than creating the surface itself, so it mirrors
+  // 'guest-user-sharing-exposure' rather than the confirmed bulk-read sinks.
+  'guest-record-access-policy-not-enforced':    { grants: ['unauth-foothold', 'data-read'] },
+  // Sensitive data present and readable — what every other capability is ultimately reaching for.
+  'encryption-coverage-unencrypted-sensitive':  { grants: ['data-read'] },
+  'sandbox-data-masking-pii-present':           { grants: ['data-read'] },
 };
 
 /** Resolve the effective capabilities for a finding (inline overrides registry; passed/inconclusive yield nothing). */

--- a/src/chains/namedChains.ts
+++ b/src/chains/namedChains.ts
@@ -2,6 +2,7 @@
 import type { RiskLevel } from '@cclabsnz/sf-core';
 import type { Finding } from '../findings/Finding.js';
 import type { Capability } from './Capability.js';
+import { capabilitiesFor } from './CapabilityRegistry.js';
 
 export interface NamedChainDef {
   id: string;
@@ -29,10 +30,18 @@ export const NAMED_CHAINS: NamedChainDef[] = [
     severity: 'CRITICAL',
     narrative:
       'An unauthenticated guest foothold combines with guest-reachable code execution or public ' +
-      'external sharing to read business data in bulk without any login.',
+      'external sharing to read business data in bulk without any login. In practice this is ' +
+      'reached over the site\'s Aura endpoint (/s/sfsites/aura) with aura.token=null: ' +
+      'RecordUiController/ACTION$executeGraphQL returns record data the guest user can see, and ' +
+      'aura.ApexAction.execute invokes @AuraEnabled Apex — which, in a class that runs without ' +
+      'sharing, skips record-level access control entirely and will accept arbitrary record ids. ' +
+      'No credentials are involved at any point, so login-based controls (MFA, IP ranges, SSO) ' +
+      'never engage.',
     remediation:
       'Remove guest object/sharing access, ensure no guest-invokable Apex runs without sharing, ' +
-      'and set external OWD to Private. Grant portal access only via sharing sets.',
+      'and set external OWD to Private. Grant portal access only via sharing sets. Because the ' +
+      'requests never reach a login page, tightening authentication does not mitigate this — the ' +
+      'object permissions, sharing model and Apex sharing declarations are the controls that apply.',
     match(present, active) {
       if (!has(present, 'unauth-foothold')) return null;
       if (!hasAny(present, 'code-exec', 'data-read-bulk', 'data-write')) return null;
@@ -43,6 +52,10 @@ export const NAMED_CHAINS: NamedChainDef[] = [
         'guest-api-access-enabled', 'guest-api-hard-delete', 'classic-sites-active',
         'portal-exposed-apex-without-sharing', 'sharing-model-external-read', 'sharing-model-external-write',
         'field-level-security-high', 'field-level-security-medium',
+        // The guardrail whose absence lets guest-owned records defeat a Private OWD, and the Flow
+        // analogue of portal-exposed Apex running without sharing.
+        'guest-record-access-policy-not-enforced',
+        'flows-autolaunched-without-sharing', 'flows-screen-without-sharing',
       ]);
       return steps.length >= 2 ? steps : null;
     },
@@ -54,8 +67,11 @@ export const NAMED_CHAINS: NamedChainDef[] = [
     narrative:
       'Live EventLogFile evidence shows unauthenticated guests probing from anonymizer/hosting IPs or ' +
       'running GraphQL object-enumeration (totalCount) sweeps, AND the org exposes objects that are ' +
-      'bulk-readable by those same guests. This is not a theoretical exposure — it is reconnaissance ' +
-      'against a confirmed exfiltration surface, i.e. an incident likely already in progress.',
+      'bulk-readable by those same guests. The sweeps arrive as AuraRequest/GraphQlQueryExecution ' +
+      'events against /s/sfsites/aura — aura://RecordUiController/ACTION$executeGraphQL asking only ' +
+      'for totalCount per object, which is how an attacker maps the readable surface before pulling ' +
+      'from it. This is not a theoretical exposure — it is reconnaissance against a confirmed ' +
+      'exfiltration surface, i.e. an incident likely already in progress.',
     remediation:
       'Treat as an active incident: block the source IPs at the WAF/CDN, close the guest bulk-read surface ' +
       '(set external OWD to Private, strip guest object read, enforce "Secure guest user record access"), ' +
@@ -83,6 +99,11 @@ export const NAMED_CHAINS: NamedChainDef[] = [
         'sharing-model-external-read', 'sharing-model-external-write', 'guest-user-baseline',
         'escalation-perms-found', 'users-author-apex', 'users-super-admin-combo',
         'login-access-policy-delegated-admins', 'login-access-policy-login-as-enabled',
+        // Admin-equivalent users off the System Administrator profile, and the toxic combinations
+        // that let one user grant themselves access, are escalation steps in their own right.
+        'privileged-access-shadow-admins',
+        'separation-of-duties-self-escalation', 'separation-of-duties-identity-takeover',
+        'separation-of-duties-grant-self-data',
       ]);
       return steps.length >= 2 ? steps : null;
     },
@@ -102,6 +123,9 @@ export const NAMED_CHAINS: NamedChainDef[] = [
         'hardcoded-credentials-found', 'custom-labels-credential-value-match', 'custom-labels-credential-name-match',
         'debug-log-active-traces', 'cors-wildcard-origin', 'cors-broad-origin',
         'named-credentials-inventory', 'named-credentials-http-endpoint', 'remote-sites-inventory',
+        // A user who can stand up connected apps and bypass API access control has provisioned
+        // their own egress path.
+        'separation-of-duties-external-exfil-channel',
       ]);
       return steps.length >= 2 ? steps : null;
     },
@@ -121,6 +145,8 @@ export const NAMED_CHAINS: NamedChainDef[] = [
       const sink = byIds(active, [
         'sharing-model-external-read', 'sharing-model-external-write',
         'field-level-security-high', 'field-level-security-medium', 'users-view-all-data',
+        'public-group-sharing-exposure', 'report-folder-access-public',
+        'encryption-coverage-unencrypted-sensitive',
       ]);
       return sink.length > 0 ? [...inj, ...sink] : null;
     },
@@ -133,7 +159,13 @@ export const NAMED_CHAINS: NamedChainDef[] = [
       'A guest-reachable Agentforce channel lets an unauthenticated attacker send prompt-injection input to an ' +
       'agent that runs as an over-privileged user (Modify/View All Data or broad object write) and can drive ' +
       'write-capable actions. Public input, privileged identity, and state-changing actions are all present at ' +
-      'once, so a single injected prompt can read, alter, or destroy data across the agent\'s reach.',
+      'once, so a single injected prompt can read, alter, or destroy data across the agent\'s reach. ' +
+      'Note this does NOT ride the site\'s Aura endpoint: agent conversations go to the org\'s messaging host ' +
+      '(<subdomain>.my.salesforce-scrt.com) over the Messaging for In-App and Web API (/iamessage/api/v2/...). ' +
+      'Guest reachability comes from that API\'s unauthenticated access-token flow, which needs only the org id ' +
+      'and the Embedded Service deployment\'s API name (esDeveloperName) — both of which appear in the ' +
+      'client-side bootstrap of any page hosting the widget. That flow is a supported configuration for public ' +
+      'support chat; the risk here is not the channel existing, it is the channel reaching a privileged agent.',
     remediation:
       'Break any one link: remove the guest/public binding, scope the agent run-as user to least privilege, ' +
       'or remove write-capable actions from the exposed agent (and add confirmation/guardrails where they must stay).',
@@ -170,6 +202,93 @@ export const NAMED_CHAINS: NamedChainDef[] = [
     },
   },
   {
+    id: 'sandbox-pii-exposure',
+    title: 'Unmasked production PII in a weakly-controlled sandbox',
+    severity: 'HIGH',
+    narrative:
+      'This sandbox holds populated PII fields — almost certainly a copy of production data that was ' +
+      'never masked — and it is not held to production access standards. Sandboxes routinely carry ' +
+      'more admins, weaker authentication and broader sharing than the org they were refreshed from, ' +
+      'so the same records sit behind materially weaker controls. The data is real; only the ' +
+      'protection is not.',
+    remediation:
+      'Run Salesforce Data Mask on the sandbox (or refresh without production data), and bring its ' +
+      'authentication and sharing configuration up to production standard for as long as real data ' +
+      'remains in it.',
+    match(_present, active) {
+      const pii = byIds(active, ['sandbox-data-masking-pii-present']);
+      if (pii.length === 0) return null;
+      const weakControls = byIds(active, [
+        'internal-user-mfa-gaps', 'trusted-ip-broad-ranges', 'mfa-portal-users-without-enforcement',
+        'public-group-sharing-exposure', 'report-folder-access-public', 'standard-profiles-in-use',
+        'privileged-access-shadow-admins', 'sharing-model-external-read', 'sharing-model-external-write',
+        'guest-user-read-access', 'guest-user-write-access', 'guest-user-sharing-exposure',
+      ]);
+      return weakControls.length > 0 ? [...pii, ...weakControls] : null;
+    },
+  },
+  {
+    id: 'insider-bulk-exfil',
+    title: 'Insider bulk export without monitoring',
+    severity: 'HIGH',
+    narrative:
+      'Business data is readable in bulk by any authenticated internal user, at least one profile or ' +
+      'permission set can export it en masse (Weekly Data Export, or API access combined with ' +
+      'View/Modify All Data), and there is no monitoring that would record the export happening. ' +
+      'Broad read plus bulk egress plus no audit trail is the insider-threat and post-credential-' +
+      'compromise path — and the missing third element is what makes it unreconstructable afterwards.',
+    remediation:
+      'Narrow the broad internal sharing, restrict Weekly Data Export and Bulk API access to a named ' +
+      'few, and enable Event Monitoring (plus forwarding to a SIEM) so bulk reads are recorded and ' +
+      'alertable.',
+    match(_present, active) {
+      const broadRead = byIds(active, [
+        'public-group-sharing-exposure', 'report-folder-access-public',
+        'users-view-all-data', 'users-modify-all-data',
+      ]);
+      const bulkEgress = byIds(active, [
+        'data-export-weekly-export', 'data-export-bulk-api-viewall',
+        'separation-of-duties-external-exfil-channel',
+      ]);
+      const blindSpot = byIds(active, [
+        'event-monitoring-disabled', 'siem-integration-not-detected', 'event-monitoring-retention-short',
+      ]);
+      if (broadRead.length === 0 || bulkEgress.length === 0 || blindSpot.length === 0) return null;
+      return [...broadRead, ...bulkEgress, ...blindSpot];
+    },
+  },
+  {
+    id: 'undetected-compromise',
+    title: 'Exploitable access with no detection coverage',
+    severity: 'MEDIUM',
+    narrative:
+      'The org already presents a real attacker capability — an unauthenticated foothold, a ' +
+      'privilege-escalation path, or org takeover — and simultaneously lacks the controls that ' +
+      'would notice it being used. Two or more of threat detection, Event Monitoring, a Transaction ' +
+      'Security policy and SIEM forwarding are absent. This chain does not add exposure; it means ' +
+      'the exposure already present would go unobserved, and an incident could not be reconstructed.',
+    remediation:
+      'Close the detection gap first: enable Event Monitoring with adequate retention, turn on threat ' +
+      'detection event storage, add a Transaction Security policy, and forward events to a SIEM. Then ' +
+      'remediate the underlying access findings.',
+    match(present, active) {
+      if (!hasAny(present, 'unauth-foothold', 'priv-esc', 'org-takeover')) return null;
+      const blindSpots = byIds(active, [
+        'threat-detection-inactive', 'threat-detection-guest-anomaly-missing',
+        'event-monitoring-disabled', 'event-monitoring-retention-short',
+        'transaction-security-policy-none', 'siem-integration-not-detected', 'siem-retention-gap',
+      ]);
+      // One missing control is a finding on its own; two or more is a systemic blind spot. Requiring
+      // two keeps this from firing on every org that has not bought Shield.
+      if (blindSpots.length < 2) return null;
+      const exposure = active.filter((f) => {
+        const g = capabilitiesFor(f).grants;
+        return g.includes('unauth-foothold') || g.includes('priv-esc') || g.includes('org-takeover');
+      });
+      return exposure.length > 0 ? [...exposure.slice(0, 3), ...blindSpots] : null;
+    },
+  },
+  {
     id: 'mfa-bypass-admin',
     title: 'MFA bypass to privileged compromise',
     severity: 'HIGH',
@@ -182,7 +301,10 @@ export const NAMED_CHAINS: NamedChainDef[] = [
       const weakness = byIds(active, [
         'trusted-ip-broad-ranges', 'internal-user-mfa-gaps', 'mfa-portal-users-without-enforcement',
       ]);
-      const targets = byIds(active, ['users-modify-all-data', 'users-view-all-data', 'users-super-admin-combo']);
+      const targets = byIds(active, [
+        'users-modify-all-data', 'users-view-all-data', 'users-super-admin-combo',
+        'privileged-access-shadow-admins', 'separation-of-duties-self-escalation',
+      ]);
       return weakness.length > 0 && targets.length > 0 ? [...weakness, ...targets] : null;
     },
   },

--- a/src/checks/impl/AgentChannelExposureCheck.ts
+++ b/src/checks/impl/AgentChannelExposureCheck.ts
@@ -13,14 +13,33 @@ interface NetworkRecord {
   GuestUserId: string | null;
 }
 
-// Messaging channels (SMS/WhatsApp/etc). Not guest-web-reachable but a real
-// inbound surface; used for inventory (info) findings.
+// Messaging channels. Used for inventory (info) findings only — we never assert an
+// agent is reachable on one, because no queryable binding ties an agent to a channel.
+//
+// Do NOT describe these as internal or authenticated. `MessagingChannel` is not just
+// SMS/WhatsApp/Facebook: creating a "Messaging for In-App and Web" channel (Setup →
+// Messaging Settings → New Channel) also creates a MessagingChannel record, and that
+// one is a public web surface reachable through the messaging API's unauthenticated
+// guest access-token flow. ChannelType would distinguish them, but the literal picklist
+// values are not confirmed here, so this check reports the count as "type not
+// determined" rather than classifying reach it has not established.
 interface MessagingChannelRecord {
   Id: string;
   MasterLabel: string | null;
-  ChannelType?: string | null;
+  // The field is MessageType, NOT ChannelType — there is no ChannelType field on
+  // MessagingChannel. Selecting one fails with INVALID_FIELD, and because the query is
+  // wrapped in a catch that returns [], that failure is silent: every channel disappears.
+  MessageType?: string | null;
+  PlatformType?: string | null;
   IsActive?: boolean | null;
 }
+
+// MessageType values that are reachable from a browser, and therefore candidate public
+// surfaces. Verified against a live org's MessagingChannel describe (2026-08); the full
+// picklist also covers Text, Phone, WhatsApp, Facebook, Line, WeChat, AppleBusinessChat,
+// Rcs, Email, Voice/PstnVoice/SipVoice/WhatsAppVoice, Alexa, GoogleHome, Custom, Omega,
+// InternalCopilot, MsCopilot and VoiceIntegrationPilot, none of which is a web endpoint.
+const WEB_MESSAGE_TYPES = new Set(['EmbeddedMessaging', 'WebChat']);
 
 // Embedded Service deployment rows (chat/messaging-for-web). A deployment tied to
 // a live site or with no authentication is a public web surface. The exact schema
@@ -39,7 +58,7 @@ interface EmbeddedServiceRecord {
 
 // A discovered public channel, normalised for reporting.
 interface PublicChannel {
-  kind: 'experience-site' | 'embedded-deployment';
+  kind: 'experience-site' | 'embedded-deployment' | 'messaging-channel-web';
   id: string;
   label: string;
   note: string;
@@ -103,6 +122,25 @@ export class AgentChannelExposureCheck implements SecurityCheck {
       });
     }
 
+    // A web-type messaging channel is a browser-reachable surface: Embedded Messaging and
+    // Chat are served to the public web and, for guests, reached through the messaging API's
+    // unauthenticated access-token flow. Treat those as public channel candidates. We still
+    // cannot bind an agent to one (no queryable binding exists), so they land in the unmapped
+    // list and are reported as an unconfirmed mapping, never as an asserted exposure.
+    for (const m of messagingChannels) {
+      if (m.IsActive === false) continue;
+      if (!m.MessageType || !WEB_MESSAGE_TYPES.has(m.MessageType)) continue;
+      publicChannels.push({
+        kind: 'messaging-channel-web',
+        id: m.Id,
+        label: m.MasterLabel ?? m.Id,
+        note:
+          `Messaging channel of type ${m.MessageType}` +
+          `${m.PlatformType ? ` (${m.PlatformType})` : ''} — a web-reachable surface, ` +
+          `available to unauthenticated visitors via the messaging API's guest access-token flow`,
+      });
+    }
+
     // Resolve agent->channel bindings from Tooling deployment configs where the
     // platform exposes them. This is the only source that lets us assert exposure
     // as fact rather than inference.
@@ -160,6 +198,10 @@ export class AgentChannelExposureCheck implements SecurityCheck {
           `The Agentforce agent "${agent.label}" (${agent.developerName}) is bound to ${channel.note}. ` +
           `Unauthenticated visitors can send this agent input, so any prompt-injection payload reaches an agent ` +
           `that executes with the data access of its run-as user${agent.runAsUserId ? ` (${agent.runAsUserId})` : ''}. ` +
+          `Reachability does not depend on the site's Aura endpoint: conversations go to the org's messaging host ` +
+          `(<subdomain>.my.salesforce-scrt.com) via the Messaging for In-App and Web API, whose unauthenticated ` +
+          `access-token flow needs only the org id and this deployment's API name (the esDeveloperName), both of ` +
+          `which are present in the client-side bootstrap of any page that hosts the widget. ` +
           `This is the exact combination behind the ForcedLeak pattern: public input channel plus a privileged agent identity.`,
         remediation:
           'Confirm this agent is intended to be publicly reachable. If so, tightly scope the run-as user (least privilege), review the agent action surface for write-capable actions, and ensure Event Monitoring / Transaction Security cover the agent. If not intended, remove the guest/public binding.',
@@ -177,21 +219,29 @@ export class AgentChannelExposureCheck implements SecurityCheck {
     // internal-only inventory value. Reported once, listing the internal channels.
     const publiclyExposedDevNames = new Set(mappedExposures.map((m) => m.agent.developerName));
     const internalAgents = activeAgents.filter((a) => !publiclyExposedDevNames.has(a.developerName));
-    const internalChannels = messagingChannels.filter((m) => m.IsActive !== false);
+    // Web-type channels have already been promoted to publicChannels above, so anything left
+    // here is a non-web inbound surface (SMS, WhatsApp, Facebook, voice, email, ...).
+    const nonWebChannels = messagingChannels.filter(
+      (m) => m.IsActive !== false && !(m.MessageType && WEB_MESSAGE_TYPES.has(m.MessageType)),
+    );
     if (internalAgents.length > 0 && unmappedPublicChannels.length === 0) {
+      const types = [...new Set(nonWebChannels.map((m) => m.MessageType).filter(Boolean))];
       findings.push({
         id: 'agent-channel-exposure-internal',
         category: this.category,
         riskLevel: 'INFO',
-        title: `${internalAgents.length} active agent(s) on internal-only channels`,
+        title: `${internalAgents.length} active agent(s) with no public channel binding confirmed`,
         detail:
-          `${internalAgents.length} active agent(s) were not found on any guest-reachable Experience Cloud site or public embedded deployment. ` +
-          (internalChannels.length > 0
-            ? `${internalChannels.length} messaging channel(s) are configured (internal / authenticated inbound surfaces). `
-            : 'No public web channels were discovered. ') +
-          `Channel reachability in Salesforce is not always expressed in queryable metadata, so treat this as "no public exposure found" rather than a guarantee.`,
+          `${internalAgents.length} active agent(s) were not found on any guest-reachable Experience Cloud site, public embedded deployment, or web-type messaging channel. ` +
+          (nonWebChannels.length > 0
+            ? `${nonWebChannels.length} non-web messaging channel(s) are active${types.length > 0 ? ` (${types.join(', ')})` : ''}. ` +
+              `These are inbound surfaces whose senders are external parties identified by phone number or account handle — not ` +
+              `Salesforce-authenticated users — but they are not browser-reachable endpoints, and no queryable binding ties an ` +
+              `agent to a messaging channel, so no exposure is asserted for them either way. `
+            : 'No web-reachable channels were discovered. ') +
+          `Channel reachability in Salesforce is not always expressed in queryable metadata, so treat this as "no public exposure found" rather than a guarantee, and not as evidence that these agents are internal-only.`,
         remediation:
-          'Confirm these agents are only exposed on authenticated/internal channels. Re-check after any new Experience Cloud site or embedded deployment goes live.',
+          'Confirm in Setup → Messaging Settings whether any of these agents is deployed on a messaging channel. Any channel of type EmbeddedMessaging or WebChat is a public web surface and is reported separately; for the remaining channels, verify who can send to them and scope each agent\'s run-as user to least privilege regardless. Re-check after any new Experience Cloud site, embedded deployment, or messaging channel goes live.',
         affectedItems: internalAgents.map((a) => ({
           label: `${a.label} (${a.developerName})`,
           note: `active v${a.activeVersion ?? '?'}${a.runAsUserId ? ` | run-as: ${a.runAsUserId}` : ''}`,
@@ -250,10 +300,18 @@ export class AgentChannelExposureCheck implements SecurityCheck {
   private async queryMessagingChannels(ctx: AuditContext): Promise<MessagingChannelRecord[]> {
     try {
       return await ctx.soql.queryAll<MessagingChannelRecord>(
-        `SELECT Id, MasterLabel, ChannelType, IsActive FROM MessagingChannel`,
+        `SELECT Id, MasterLabel, MessageType, PlatformType, IsActive FROM MessagingChannel`,
       );
     } catch {
-      return [];
+      // Fall back to the minimal projection so an org missing the type fields still yields an
+      // inventory count, rather than reporting no channels at all.
+      try {
+        return await ctx.soql.queryAll<MessagingChannelRecord>(
+          `SELECT Id, MasterLabel, IsActive FROM MessagingChannel`,
+        );
+      } catch {
+        return [];
+      }
     }
   }
 

--- a/src/compliance/catalogs/gdpr.ts
+++ b/src/compliance/catalogs/gdpr.ts
@@ -1,0 +1,56 @@
+import type { ControlDef } from '../types.js';
+
+// GDPR — Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016
+// on the protection of natural persons with regard to the processing of personal data and on the
+// free movement of such data, and repealing Directive 95/46/EC.
+//
+// Article headings and the quoted text of Art. 5(1)(f), 25 and 32(1)(a)-(d) verified 2026-08
+// against the consolidated regulation text; the Official Journal (OJ L 119, 4.5.2016) is the
+// canonical reference.
+//
+// Scope note: GDPR is a regulation about processing, not a technical control set, so only the
+// articles that a read-only Salesforce org-configuration review can produce evidence for are
+// catalogued. Articles covering lawful basis, data-subject rights, DPIAs (Art. 35), controller /
+// processor contracts and supervisory-authority procedure are out of scope for this tool and
+// deliberately absent — their absence is not a claim that they do not apply.
+//
+// Where a paragraph is mapped rather than a whole article (Art. 5(1)(f), Art. 32(1)(a)/(b)/(d)),
+// the id names the paragraph so a finding cites the specific obligation, not the article at large.
+const V = 'Regulation (EU) 2016/679';
+const URL = 'https://eur-lex.europa.eu/eli/reg/2016/679/oj/eng';
+const ref = (cite: string): string => `Regulation (EU) 2016/679, ${cite}`;
+
+export const GDPR_CONTROLS: ControlDef[] = [
+  { id: 'GDPR-Art5(1)(f)', framework: 'GDPR', version: V,
+    title: 'Integrity and confidentiality',
+    requirement: 'Personal data shall be processed in a manner that ensures appropriate security of the personal data, including protection against unauthorised or unlawful processing and against accidental loss, destruction or damage, using appropriate technical or organisational measures.',
+    sourceRef: ref('Art. 5(1)(f)'), url: URL, verified: true },
+  { id: 'GDPR-Art25', framework: 'GDPR', version: V,
+    title: 'Data protection by design and by default',
+    requirement: 'The controller shall implement appropriate technical and organisational measures for ensuring that, by default, only personal data which are necessary for each specific purpose are processed — including their accessibility. Such measures shall ensure that by default personal data are not made accessible without the individual\'s intervention to an indefinite number of natural persons.',
+    sourceRef: ref('Art. 25(1)-(2)'), url: URL, verified: true },
+  { id: 'GDPR-Art30', framework: 'GDPR', version: V,
+    title: 'Records of processing activities',
+    requirement: 'Each controller shall maintain a record of processing activities under its responsibility, including the categories of personal data processed, the categories of recipients to whom the data have been disclosed, and transfers to third countries.',
+    sourceRef: ref('Art. 30(1)'), url: URL, verified: true },
+  { id: 'GDPR-Art32(1)(a)', framework: 'GDPR', version: V,
+    title: 'Pseudonymisation and encryption of personal data',
+    requirement: 'Taking account of the state of the art and the risks of the processing, the controller and processor shall implement appropriate technical and organisational measures including the pseudonymisation and encryption of personal data.',
+    sourceRef: ref('Art. 32(1)(a)'), url: URL, verified: true },
+  { id: 'GDPR-Art32(1)(b)', framework: 'GDPR', version: V,
+    title: 'Ongoing confidentiality, integrity, availability and resilience',
+    requirement: 'The controller and processor shall implement measures providing the ability to ensure the ongoing confidentiality, integrity, availability and resilience of processing systems and services.',
+    sourceRef: ref('Art. 32(1)(b)'), url: URL, verified: true },
+  { id: 'GDPR-Art32(1)(d)', framework: 'GDPR', version: V,
+    title: 'Regular testing and evaluation of security measures',
+    requirement: 'The controller and processor shall implement a process for regularly testing, assessing and evaluating the effectiveness of technical and organisational measures for ensuring the security of the processing.',
+    sourceRef: ref('Art. 32(1)(d)'), url: URL, verified: true },
+  { id: 'GDPR-Art33', framework: 'GDPR', version: V,
+    title: 'Notification of a personal data breach to the supervisory authority',
+    requirement: 'In the case of a personal data breach, the controller shall without undue delay and, where feasible, not later than 72 hours after having become aware of it, notify the breach to the competent supervisory authority. Detecting and characterising a breach is a precondition of meeting that deadline.',
+    sourceRef: ref('Art. 33(1)'), url: URL, verified: true },
+  { id: 'GDPR-Art44', framework: 'GDPR', version: V,
+    title: 'General principle for transfers',
+    requirement: 'Any transfer of personal data to a third country or international organisation shall take place only if the conditions of Chapter V are met, including onward transfers. All provisions of that chapter shall be applied to ensure the level of protection guaranteed by this Regulation is not undermined.',
+    sourceRef: ref('Art. 44'), url: URL, verified: true },
+];

--- a/src/compliance/catalogs/hipaa.ts
+++ b/src/compliance/catalogs/hipaa.ts
@@ -1,0 +1,100 @@
+import type { ControlDef } from '../types.js';
+
+// HIPAA Security Rule — 45 CFR Part 164, Subpart C ("Security Standards for the Protection of
+// Electronic Protected Health Information"), as amended by the 2013 Omnibus Rule.
+//
+// Version pinning matters here. HHS published an NPRM on 2025-01-06 that would rewrite these
+// safeguards — removing the Required/Addressable distinction and making encryption, MFA and
+// network segmentation mandatory. As of 2026-08 that rule is still PROPOSED, not final, so this
+// catalog maps the operative rule. When the final rule lands, `version` and the affected
+// `requirement` texts must be re-pinned and re-verified, not silently amended.
+//
+// Standard headings and implementation-specification names verified 2026-08 against the
+// codified text of 45 CFR 164.308 / 164.310 / 164.312, including each spec's
+// Required vs Addressable designation. `requirement` quotes the regulatory text.
+//
+// Scope note: only safeguards a read-only Salesforce org-configuration review can speak to are
+// catalogued. The physical safeguards (164.310), contingency planning (164.308(a)(7)) and the
+// documentation requirements (164.316) are out of scope for this tool and deliberately absent —
+// their absence is not a claim that they do not apply.
+const V = '45 CFR Part 164 Subpart C (HIPAA Security Rule, 2013 Omnibus)';
+const URL = 'https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-164/subpart-C';
+const ref = (cite: string): string => `45 CFR ${cite}`;
+
+export const HIPAA_CONTROLS: ControlDef[] = [
+  // --- 164.308 Administrative safeguards ---
+  { id: 'HIPAA-164.308(a)(1)(ii)(A)', framework: 'HIPAA', version: V,
+    title: 'Risk analysis (Required)',
+    requirement: 'Conduct an accurate and thorough assessment of the potential risks and vulnerabilities to the confidentiality, integrity, and availability of electronic protected health information held by the covered entity or business associate.',
+    sourceRef: ref('164.308(a)(1)(ii)(A)'), url: URL, verified: true },
+  { id: 'HIPAA-164.308(a)(1)(ii)(B)', framework: 'HIPAA', version: V,
+    title: 'Risk management (Required)',
+    requirement: 'Implement security measures sufficient to reduce risks and vulnerabilities to a reasonable and appropriate level.',
+    sourceRef: ref('164.308(a)(1)(ii)(B)'), url: URL, verified: true },
+  { id: 'HIPAA-164.308(a)(1)(ii)(D)', framework: 'HIPAA', version: V,
+    title: 'Information system activity review (Required)',
+    requirement: 'Implement procedures to regularly review records of information system activity, such as audit logs, access reports, and security incident tracking reports.',
+    sourceRef: ref('164.308(a)(1)(ii)(D)'), url: URL, verified: true },
+  { id: 'HIPAA-164.308(a)(3)', framework: 'HIPAA', version: V,
+    title: 'Workforce security',
+    requirement: 'Implement policies and procedures to ensure that all members of the workforce have appropriate access to electronic protected health information, and to prevent those who do not have access from obtaining access — including termination procedures for ending access when employment or authorisation ends.',
+    sourceRef: ref('164.308(a)(3)'), url: URL, verified: true },
+  { id: 'HIPAA-164.308(a)(4)', framework: 'HIPAA', version: V,
+    title: 'Information access management',
+    requirement: 'Implement policies and procedures for authorising access to electronic protected health information that are consistent with the applicable requirements of subpart E, including access authorisation and access establishment and modification.',
+    sourceRef: ref('164.308(a)(4)'), url: URL, verified: true },
+  { id: 'HIPAA-164.308(a)(5)(ii)(C)', framework: 'HIPAA', version: V,
+    title: 'Log-in monitoring (Addressable)',
+    requirement: 'Procedures for monitoring log-in attempts and reporting discrepancies.',
+    sourceRef: ref('164.308(a)(5)(ii)(C)'), url: URL, verified: true },
+  { id: 'HIPAA-164.308(a)(5)(ii)(D)', framework: 'HIPAA', version: V,
+    title: 'Password management (Addressable)',
+    requirement: 'Procedures for creating, changing, and safeguarding passwords.',
+    sourceRef: ref('164.308(a)(5)(ii)(D)'), url: URL, verified: true },
+  { id: 'HIPAA-164.308(a)(6)', framework: 'HIPAA', version: V,
+    title: 'Security incident procedures',
+    requirement: 'Implement policies and procedures to address security incidents, including identifying and responding to suspected or known security incidents, mitigating their harmful effects, and documenting incidents and their outcomes.',
+    sourceRef: ref('164.308(a)(6)'), url: URL, verified: true },
+  { id: 'HIPAA-164.308(a)(8)', framework: 'HIPAA', version: V,
+    title: 'Evaluation',
+    requirement: 'Perform a periodic technical and nontechnical evaluation, in response to environmental or operational changes affecting the security of electronic protected health information, that establishes the extent to which security policies and procedures meet the requirements of this subpart.',
+    sourceRef: ref('164.308(a)(8)'), url: URL, verified: true },
+
+  // --- 164.312 Technical safeguards ---
+  { id: 'HIPAA-164.312(a)(1)', framework: 'HIPAA', version: V,
+    title: 'Access control',
+    requirement: 'Implement technical policies and procedures for electronic information systems that maintain electronic protected health information to allow access only to those persons or software programs that have been granted access rights as specified in 164.308(a)(4).',
+    sourceRef: ref('164.312(a)(1)'), url: URL, verified: true },
+  { id: 'HIPAA-164.312(a)(2)(i)', framework: 'HIPAA', version: V,
+    title: 'Unique user identification (Required)',
+    requirement: 'Assign a unique name and/or number for identifying and tracking user identity.',
+    sourceRef: ref('164.312(a)(2)(i)'), url: URL, verified: true },
+  { id: 'HIPAA-164.312(a)(2)(iii)', framework: 'HIPAA', version: V,
+    title: 'Automatic logoff (Addressable)',
+    requirement: 'Implement electronic procedures that terminate an electronic session after a predetermined time of inactivity.',
+    sourceRef: ref('164.312(a)(2)(iii)'), url: URL, verified: true },
+  { id: 'HIPAA-164.312(a)(2)(iv)', framework: 'HIPAA', version: V,
+    title: 'Encryption and decryption (Addressable)',
+    requirement: 'Implement a mechanism to encrypt and decrypt electronic protected health information.',
+    sourceRef: ref('164.312(a)(2)(iv)'), url: URL, verified: true },
+  { id: 'HIPAA-164.312(b)', framework: 'HIPAA', version: V,
+    title: 'Audit controls',
+    requirement: 'Implement hardware, software, and/or procedural mechanisms that record and examine activity in information systems that contain or use electronic protected health information.',
+    sourceRef: ref('164.312(b)'), url: URL, verified: true },
+  { id: 'HIPAA-164.312(c)(1)', framework: 'HIPAA', version: V,
+    title: 'Integrity',
+    requirement: 'Implement policies and procedures to protect electronic protected health information from improper alteration or destruction.',
+    sourceRef: ref('164.312(c)(1)'), url: URL, verified: true },
+  { id: 'HIPAA-164.312(d)', framework: 'HIPAA', version: V,
+    title: 'Person or entity authentication',
+    requirement: 'Implement procedures to verify that a person or entity seeking access to electronic protected health information is the one claimed.',
+    sourceRef: ref('164.312(d)'), url: URL, verified: true },
+  { id: 'HIPAA-164.312(e)(1)', framework: 'HIPAA', version: V,
+    title: 'Transmission security',
+    requirement: 'Implement technical security measures to guard against unauthorised access to electronic protected health information that is being transmitted over an electronic communications network.',
+    sourceRef: ref('164.312(e)(1)'), url: URL, verified: true },
+  { id: 'HIPAA-164.312(e)(2)(ii)', framework: 'HIPAA', version: V,
+    title: 'Encryption in transmission (Addressable)',
+    requirement: 'Implement a mechanism to encrypt electronic protected health information whenever deemed appropriate.',
+    sourceRef: ref('164.312(e)(2)(ii)'), url: URL, verified: true },
+];

--- a/src/compliance/catalogs/index.ts
+++ b/src/compliance/catalogs/index.ts
@@ -7,6 +7,8 @@ import { SBS_CONTROLS } from './sbs.js';
 import { PRIVACY_ACT_CONTROLS } from './privacyAct.js';
 import { HISO10029_CONTROLS } from './hiso10029.js';
 import { NZISM_CONTROLS } from './nzism.js';
+import { HIPAA_CONTROLS } from './hipaa.js';
+import { GDPR_CONTROLS } from './gdpr.js';
 
 export const ALL_CONTROLS: ControlDef[] = [
   ...OWASP_CONTROLS,
@@ -17,6 +19,8 @@ export const ALL_CONTROLS: ControlDef[] = [
   ...PRIVACY_ACT_CONTROLS,
   ...HISO10029_CONTROLS,
   ...NZISM_CONTROLS,
+  ...HIPAA_CONTROLS,
+  ...GDPR_CONTROLS,
 ];
 
 const BY_ID: Map<string, ControlDef> = new Map(ALL_CONTROLS.map((c) => [c.id, c]));

--- a/src/compliance/mapping.ts
+++ b/src/compliance/mapping.ts
@@ -1,6 +1,5 @@
 // Maps each check id to the compliance control ids it relates to.
-// Migrated from the former ComplianceMapping. HIPAA/GDPR ids are intentionally omitted
-// until their catalogs land (later plan). A08/A10 are mapped precisely:
+// Migrated from the former ComplianceMapping. A08/A10 are mapped precisely:
 //   A10 (SSRF) → egress controls (remote-sites, csp-trusted-sites, named-credentials)
 //   A08 (Software & Data Integrity) → installed-packages, deployment-identity
 // NZ pack control ids (HISO/NZISM/Privacy Act) are layered on by domain via NZ_CROSSWALK below.
@@ -108,50 +107,124 @@ const BASE_CHECK_CONTROL_MAP: Record<string, string[]> = {
   'trusted-url-hygiene':     ['OWASP-A05', 'OWASP-A10', 'SOC2-CC6.6', 'ISO-A.8.26', 'LLM01', 'LLM05'],
 };
 
-// NZ pack crosswalk — each check belongs to one domain; the domain's NZ control ids are
-// layered onto its base entry. HISO/NZISM are domain/chapter-level drafts; Privacy Act IPPs
-// are statute-level. All verified:false until the verification pass.
-const NZ_CROSSWALK: Array<{ controls: string[]; checks: string[] }> = [
-  { controls: ['HISO-AC', 'NZISM-AC', 'PRIVACY-IPP5'],
-    checks: ['users-and-admins', 'permissions', 'sharing-model', 'public-group-sharing', 'guest-user-access',
-             'field-level-security', 'standard-profiles', 'api-client-permission', 'integration-users',
-             'escalation-perms', 'report-folder-access', 'apex-crud-fls', 'apex-rest-endpoint',
-             'guest-executable-apex', 'experience-cloud-site', 'content-links', 'apex-sharing', 'flows-without-sharing',
-             'public-content-exposure', 'privileged-access', 'separation-of-duties',
-             'guest-object-exposure', 'guest-site-options', 'guest-record-access-policy',
-             'login-access-policy', 'data-export-access', 'classic-sites', 'guest-api-access'] },
-  { controls: ['HISO-AUTH', 'NZISM-AUTH', 'PRIVACY-IPP5'],
-    checks: ['login-session', 'ip-restrictions', 'password-session-policy', 'sso-enforcement', 'mfa-enforcement',
-             'trusted-ip-ranges', 'my-domain-login-policy', 'high-assurance-session', 'internal-user-mfa',
-             'mfa-registration', 'mfa-method-strength', 'failed-login-detection', 'enhanced-domains',
-             'auth-providers'] },
-  { controls: ['HISO-CRYPTO', 'NZISM-CRYPTO', 'PRIVACY-IPP5'],
-    checks: ['named-credentials', 'hardcoded-credentials', 'custom-settings', 'certificate-expiry', 'custom-labels-credential', 'external-credentials', 'encryption-coverage'] },
-  { controls: ['HISO-LOG', 'NZISM-LOG'],
-    checks: ['audit-trail', 'apex-logging', 'event-monitoring', 'siem-integration', 'anonymous-apex-audit',
-             'debug-log-access', 'transaction-security-policy', 'threat-detection', 'guest-traffic-anomaly',
-             'login-anomaly'] },
-  { controls: ['HISO-DEV', 'NZISM-SW'],
-    checks: ['code-security', 'visualforce-xss', 'scheduled-apex'] },
-  { controls: ['HISO-COMM', 'NZISM-NET', 'PRIVACY-IPP12'],
-    checks: ['remote-sites', 'csp-trusted-sites', 'connected-apps', 'connected-app-scope', 'connected-app-inactivity', 'cors-allowlist',
-             'email-security', 'outbound-messages', 'experience-csp'] },
-  { controls: ['HISO-DATA', 'PRIVACY-IPP5'],
-    checks: ['data-classification', 'field-history-tracking', 'sandbox-data-masking'] },
-  { controls: ['HISO-GOV', 'NZISM-CONFIG'],
-    checks: ['health-check', 'api-limits', 'release-updates', 'legacy-api-version', 'installed-packages', 'deployment-identity', 'session-hardening'] },
-  { controls: ['PRIVACY-IPP9'],
-    checks: ['inactive-users'] },
+// Domain groupings. Each check belongs to exactly one domain, and a domain's control ids are
+// layered onto every base entry in it. Shared by the NZ pack and the HIPAA/GDPR crosswalk below
+// so the two cannot drift apart in which checks they consider part of a domain.
+const DOMAIN = {
+  accessControl: ['users-and-admins', 'permissions', 'sharing-model', 'public-group-sharing', 'guest-user-access',
+                  'field-level-security', 'standard-profiles', 'api-client-permission', 'integration-users',
+                  'escalation-perms', 'report-folder-access', 'apex-crud-fls', 'apex-rest-endpoint',
+                  'guest-executable-apex', 'experience-cloud-site', 'content-links', 'apex-sharing', 'flows-without-sharing',
+                  'public-content-exposure', 'privileged-access', 'separation-of-duties',
+                  'guest-object-exposure', 'guest-site-options', 'guest-record-access-policy',
+                  'login-access-policy', 'data-export-access', 'classic-sites', 'guest-api-access'],
+  authentication: ['login-session', 'ip-restrictions', 'password-session-policy', 'sso-enforcement', 'mfa-enforcement',
+                   'trusted-ip-ranges', 'my-domain-login-policy', 'high-assurance-session', 'internal-user-mfa',
+                   'mfa-registration', 'mfa-method-strength', 'failed-login-detection', 'enhanced-domains',
+                   'auth-providers'],
+  crypto: ['named-credentials', 'hardcoded-credentials', 'custom-settings', 'certificate-expiry', 'custom-labels-credential', 'external-credentials', 'encryption-coverage'],
+  logging: ['audit-trail', 'apex-logging', 'event-monitoring', 'siem-integration', 'anonymous-apex-audit',
+            'debug-log-access', 'transaction-security-policy', 'threat-detection', 'guest-traffic-anomaly',
+            'login-anomaly'],
+  devSecurity: ['code-security', 'visualforce-xss', 'scheduled-apex'],
+  network: ['remote-sites', 'csp-trusted-sites', 'connected-apps', 'connected-app-scope', 'connected-app-inactivity', 'cors-allowlist',
+            'email-security', 'outbound-messages', 'experience-csp'],
+  dataGovernance: ['data-classification', 'field-history-tracking', 'sandbox-data-masking'],
+  configGovernance: ['health-check', 'api-limits', 'release-updates', 'legacy-api-version', 'installed-packages', 'deployment-identity', 'session-hardening'],
+  accountLifecycle: ['inactive-users'],
+  // Agentforce / GenAI. The NZ pack does not map these (HISO/NZISM predate agentic platforms and
+  // have no chapter that fits); HIPAA and GDPR do, because an over-privileged agent user reading
+  // PHI or personal data is squarely an access-control and security-of-processing question.
+  aiAgents: ['agent-inventory', 'agent-user-privilege', 'agent-action-surface', 'agent-channel-exposure',
+             'agent-monitoring-coverage', 'trusted-url-hygiene'],
+} as const;
+
+// NZ pack crosswalk — HISO/NZISM are domain/chapter-level; Privacy Act IPPs are statute-level.
+const NZ_CROSSWALK: Array<{ controls: string[]; checks: readonly string[] }> = [
+  { controls: ['HISO-AC', 'NZISM-AC', 'PRIVACY-IPP5'], checks: DOMAIN.accessControl },
+  { controls: ['HISO-AUTH', 'NZISM-AUTH', 'PRIVACY-IPP5'], checks: DOMAIN.authentication },
+  { controls: ['HISO-CRYPTO', 'NZISM-CRYPTO', 'PRIVACY-IPP5'], checks: DOMAIN.crypto },
+  { controls: ['HISO-LOG', 'NZISM-LOG'], checks: DOMAIN.logging },
+  { controls: ['HISO-DEV', 'NZISM-SW'], checks: DOMAIN.devSecurity },
+  { controls: ['HISO-COMM', 'NZISM-NET', 'PRIVACY-IPP12'], checks: DOMAIN.network },
+  { controls: ['HISO-DATA', 'PRIVACY-IPP5'], checks: DOMAIN.dataGovernance },
+  { controls: ['HISO-GOV', 'NZISM-CONFIG'], checks: DOMAIN.configGovernance },
+  { controls: ['PRIVACY-IPP9'], checks: DOMAIN.accountLifecycle },
 ];
+
+// HIPAA / GDPR crosswalk — the domain-wide obligations. Anything narrower than a whole domain is
+// mapped per check in REGULATORY_PRECISE below rather than swept across the domain, because these
+// ids name a specific implementation specification or article paragraph: claiming "automatic
+// logoff" against all fourteen authentication checks would be the imprecision the sourced catalog
+// exists to avoid.
+const REGULATORY_CROSSWALK: Array<{ controls: string[]; checks: readonly string[] }> = [
+  { controls: ['HIPAA-164.312(a)(1)', 'HIPAA-164.308(a)(4)', 'GDPR-Art5(1)(f)', 'GDPR-Art25', 'GDPR-Art32(1)(b)'],
+    checks: DOMAIN.accessControl },
+  { controls: ['HIPAA-164.312(d)', 'GDPR-Art5(1)(f)', 'GDPR-Art32(1)(b)'],
+    checks: DOMAIN.authentication },
+  { controls: ['HIPAA-164.312(a)(2)(iv)', 'GDPR-Art32(1)(a)', 'GDPR-Art5(1)(f)'],
+    checks: DOMAIN.crypto },
+  { controls: ['HIPAA-164.312(b)', 'HIPAA-164.308(a)(1)(ii)(D)', 'GDPR-Art32(1)(b)', 'GDPR-Art33'],
+    checks: DOMAIN.logging },
+  { controls: ['HIPAA-164.312(c)(1)', 'GDPR-Art25', 'GDPR-Art32(1)(b)'],
+    checks: DOMAIN.devSecurity },
+  { controls: ['HIPAA-164.312(e)(1)', 'GDPR-Art44', 'GDPR-Art32(1)(b)'],
+    checks: DOMAIN.network },
+  { controls: ['HIPAA-164.308(a)(1)(ii)(A)', 'HIPAA-164.312(c)(1)', 'GDPR-Art30', 'GDPR-Art5(1)(f)'],
+    checks: DOMAIN.dataGovernance },
+  { controls: ['HIPAA-164.308(a)(1)(ii)(B)', 'HIPAA-164.308(a)(8)', 'GDPR-Art32(1)(d)'],
+    checks: DOMAIN.configGovernance },
+  { controls: ['HIPAA-164.308(a)(3)', 'GDPR-Art5(1)(f)'],
+    checks: DOMAIN.accountLifecycle },
+];
+
+// Per-check HIPAA/GDPR additions, where the obligation is narrower than its domain.
+const REGULATORY_PRECISE: Record<string, string[]> = {
+  // Shared/service identities vs "assign a unique name and/or number for identifying and tracking user identity".
+  'integration-users':          ['HIPAA-164.312(a)(2)(i)'],
+  // Session inactivity timeout is the automatic-logoff specification; password rules are their own.
+  'password-session-policy':    ['HIPAA-164.312(a)(2)(iii)', 'HIPAA-164.308(a)(5)(ii)(D)'],
+  'session-hardening':          ['HIPAA-164.312(a)(2)(iii)'],
+  // Monitoring log-in attempts and reporting discrepancies.
+  'login-session':              ['HIPAA-164.308(a)(5)(ii)(C)'],
+  'failed-login-detection':     ['HIPAA-164.308(a)(5)(ii)(C)'],
+  'login-anomaly':              ['HIPAA-164.308(a)(5)(ii)(C)'],
+  // Identifying and responding to suspected or known security incidents.
+  'transaction-security-policy':['HIPAA-164.308(a)(6)'],
+  'threat-detection':           ['HIPAA-164.308(a)(6)'],
+  'guest-traffic-anomaly':      ['HIPAA-164.308(a)(6)'],
+  // Cleartext transport of PHI/personal data — encryption in transmission.
+  'remote-sites':               ['HIPAA-164.312(e)(2)(ii)'],
+  'csp-trusted-sites':          ['HIPAA-164.312(e)(2)(ii)'],
+  'outbound-messages':          ['HIPAA-164.312(e)(2)(ii)'],
+  'email-security':             ['HIPAA-164.312(e)(2)(ii)'],
+  'experience-csp':             ['HIPAA-164.312(e)(2)(ii)'],
+  // Data Mask is pseudonymisation in the Art. 32(1)(a) sense; unmasked prod data in a sandbox is
+  // also a by-default-accessibility failure under Art. 25.
+  'sandbox-data-masking':       ['GDPR-Art32(1)(a)', 'GDPR-Art25'],
+  // Agentforce / GenAI — see DOMAIN.aiAgents.
+  'agent-inventory':            ['HIPAA-164.308(a)(4)', 'GDPR-Art30'],
+  'agent-user-privilege':       ['HIPAA-164.312(a)(1)', 'HIPAA-164.308(a)(4)', 'GDPR-Art5(1)(f)', 'GDPR-Art32(1)(b)'],
+  'agent-action-surface':       ['HIPAA-164.312(a)(1)', 'HIPAA-164.312(c)(1)', 'GDPR-Art25'],
+  'agent-channel-exposure':     ['HIPAA-164.312(a)(1)', 'GDPR-Art25', 'GDPR-Art5(1)(f)'],
+  'agent-monitoring-coverage':  ['HIPAA-164.312(b)', 'HIPAA-164.308(a)(1)(ii)(D)', 'GDPR-Art33'],
+  'trusted-url-hygiene':        ['HIPAA-164.312(e)(1)', 'GDPR-Art44'],
+};
 
 function buildCheckControlMap(): Record<string, string[]> {
   const map: Record<string, string[]> = {};
   for (const [check, ids] of Object.entries(BASE_CHECK_CONTROL_MAP)) map[check] = [...ids];
-  for (const group of NZ_CROSSWALK) {
+  for (const group of [...NZ_CROSSWALK, ...REGULATORY_CROSSWALK]) {
     for (const check of group.checks) {
       (map[check] ??= []).push(...group.controls);
     }
   }
+  for (const [check, ids] of Object.entries(REGULATORY_PRECISE)) {
+    (map[check] ??= []).push(...ids);
+  }
+  // A control can arrive from both a crosswalk and a precise entry; a compliance matrix must not
+  // render the same control twice for one check.
+  for (const check of Object.keys(map)) map[check] = [...new Set(map[check])];
   return map;
 }
 

--- a/test/unit/chains/chainNarrativeVectors.test.ts
+++ b/test/unit/chains/chainNarrativeVectors.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NAMED_CHAINS } from '../../../src/chains/namedChains.js';
+
+/**
+ * The guest chains describe a concrete request path, not just an abstract "exposure". That detail is
+ * the difference between a client reading "guest exposure" as theoretical and understanding that an
+ * unauthenticated HTTP request returns their data, so it is worth pinning:
+ *
+ *   - the endpoint and Aura action must stay spelled the same way in the chain narratives as in
+ *     GuestObjectExposureCheck, which is where the reachability grading derives it from;
+ *   - the narratives name the vector but must not carry a copy-pasteable exploit body, because they
+ *     are rendered into a client-facing executive report that circulates beyond the security team.
+ */
+
+const ROOT = process.cwd();
+const AURA_PATH = '/s/sfsites/aura';
+const GRAPHQL_ACTION = 'RecordUiController/ACTION$executeGraphQL';
+
+const narrativeOf = (id: string): string => {
+  const chain = NAMED_CHAINS.find((c) => c.id === id);
+  expect(chain).toBeDefined();
+  return `${chain!.narrative} ${chain!.remediation}`;
+};
+
+describe('guest chain narratives name the actual request path', () => {
+  it('unauth-bulk-exfil names the Aura endpoint and both read vectors', () => {
+    const text = narrativeOf('unauth-bulk-exfil');
+    expect(text).toContain(AURA_PATH);
+    expect(text).toContain('aura.token=null');
+    expect(text).toContain('executeGraphQL');
+    expect(text).toContain('aura.ApexAction.execute');
+    // The point a reader must not miss: authentication controls are not in the path at all.
+    expect(text).toMatch(/MFA|login/i);
+  });
+
+  it('active-guest-exfil names the recon signature and where it is observed', () => {
+    const text = narrativeOf('active-guest-exfil');
+    expect(text).toContain(AURA_PATH);
+    expect(text).toContain('totalCount');
+    expect(text).toContain('AuraRequest');
+  });
+
+  it('uses the same endpoint and action spelling as the check that grades reachability', () => {
+    const check = readFileSync(
+      join(ROOT, 'src/checks/impl/GuestObjectExposureCheck.ts'), 'utf8',
+    );
+    // If the check's wording is ever revised, the chain narratives must be revised with it.
+    expect(check).toContain(AURA_PATH);
+    expect(check).toContain(GRAPHQL_ACTION);
+    const chains = readFileSync(join(ROOT, 'src/chains/namedChains.ts'), 'utf8');
+    expect(chains).toContain(AURA_PATH);
+  });
+
+  it('agent channels name the messaging host, not the Aura endpoint', () => {
+    // Verified 2026-08 against the Messaging for In-App and Web API: agent conversations go to the
+    // org's SCRT2 messaging host, and guest reachability comes from that API's unauthenticated
+    // access-token flow keyed on orgId + esDeveloperName. They do NOT traverse /s/sfsites/aura.
+    // Conflating the two would put a wrong endpoint in a client deliverable, so it is pinned.
+    const text = narrativeOf('prompt-injection-blast-radius');
+    expect(text).toContain('my.salesforce-scrt.com');
+    expect(text).toContain('/iamessage/api/v2');
+    expect(text).toContain('esDeveloperName');
+    expect(text).not.toContain(AURA_PATH);
+  });
+
+  it('keeps the guest-data and agent-channel vectors distinct', () => {
+    // The guest bulk-read chains must not claim the messaging host, and the agent chain must not
+    // claim the Aura endpoint. One sentence copied between them would make both wrong.
+    expect(narrativeOf('unauth-bulk-exfil')).not.toContain('salesforce-scrt.com');
+    expect(narrativeOf('active-guest-exfil')).not.toContain('salesforce-scrt.com');
+  });
+
+  it('stops short of a copy-pasteable exploit in any narrative', () => {
+    // Naming the endpoint is standard pentest reporting; shipping a working request body into a
+    // client deliverable is a different decision, and this encodes that it was made deliberately.
+    for (const chain of NAMED_CHAINS) {
+      const text = `${chain.narrative} ${chain.remediation}`;
+      expect(text).not.toMatch(/curl |POST \/|message=\{|aura\.context=/i);
+    }
+  });
+});

--- a/test/unit/chains/namedChains.test.ts
+++ b/test/unit/chains/namedChains.test.ts
@@ -71,9 +71,13 @@ describe('NAMED_CHAINS', () => {
     expect(chain.match(present(findings), findings)).not.toBeNull();
   });
 
-  it('every named chain has a CRITICAL or HIGH severity and non-empty narrative', () => {
+  // Named chains carry a floor of MEDIUM: they are correlations someone hand-modelled, so they must
+  // outrank the emergent "potential path" output. MEDIUM is reserved for a chain that adds no new
+  // exposure of its own — `undetected-compromise` reports that exposure already present would go
+  // unobserved, which would be overstated as HIGH and is why this is not a CRITICAL/HIGH-only rule.
+  it('every named chain has at least MEDIUM severity and a non-empty narrative', () => {
     for (const c of NAMED_CHAINS) {
-      expect(['CRITICAL', 'HIGH']).toContain(c.severity);
+      expect(['CRITICAL', 'HIGH', 'MEDIUM']).toContain(c.severity);
       expect(c.narrative.length).toBeGreaterThan(0);
       expect(c.remediation.length).toBeGreaterThan(0);
     }

--- a/test/unit/chains/newNamedChains.test.ts
+++ b/test/unit/chains/newNamedChains.test.ts
@@ -1,0 +1,126 @@
+import { NAMED_CHAINS } from '../../../src/chains/namedChains.js';
+import { ChainEngine } from '../../../src/chains/ChainEngine.js';
+import { capabilitiesFor } from '../../../src/chains/CapabilityRegistry.js';
+import type { Finding } from '../../../src/findings/Finding.js';
+import type { Capability } from '../../../src/chains/Capability.js';
+
+function f(id: string, extra: Partial<Finding> = {}): Finding {
+  return { id, checkId: id, category: 'x', riskLevel: 'HIGH', title: id, detail: '', remediation: '', ...extra };
+}
+
+/** Run one named chain definition directly, deriving `present` the way ChainEngine does. */
+function match(chainId: string, findings: Finding[]): Finding[] | null {
+  const def = NAMED_CHAINS.find((c) => c.id === chainId);
+  if (!def) throw new Error(`no such chain: ${chainId}`);
+  const present = new Set<Capability>();
+  for (const finding of findings) for (const c of capabilitiesFor(finding).grants) present.add(c);
+  return def.match(present, findings);
+}
+
+describe('sandbox-pii-exposure', () => {
+  it('fires when unmasked sandbox PII meets a weak control', () => {
+    const steps = match('sandbox-pii-exposure', [
+      f('sandbox-data-masking-pii-present'),
+      f('internal-user-mfa-gaps'),
+    ]);
+    expect(steps?.map((s) => s.id)).toEqual(['sandbox-data-masking-pii-present', 'internal-user-mfa-gaps']);
+  });
+
+  it('does not fire on unmasked PII alone', () => {
+    expect(match('sandbox-pii-exposure', [f('sandbox-data-masking-pii-present')])).toBeNull();
+  });
+
+  it('does not fire on weak controls without the PII', () => {
+    expect(match('sandbox-pii-exposure', [f('internal-user-mfa-gaps')])).toBeNull();
+  });
+});
+
+describe('insider-bulk-exfil', () => {
+  const broad = f('public-group-sharing-exposure');
+  const egress = f('data-export-weekly-export');
+  const blind = f('event-monitoring-disabled');
+
+  it('fires only with broad read, bulk egress and a monitoring blind spot', () => {
+    const steps = match('insider-bulk-exfil', [broad, egress, blind]);
+    expect(steps?.map((s) => s.id).sort()).toEqual(
+      ['data-export-weekly-export', 'event-monitoring-disabled', 'public-group-sharing-exposure'],
+    );
+  });
+
+  it('does not fire when the org is monitored', () => {
+    expect(match('insider-bulk-exfil', [broad, egress])).toBeNull();
+  });
+
+  it('does not fire without a bulk-egress path', () => {
+    expect(match('insider-bulk-exfil', [broad, blind])).toBeNull();
+  });
+
+  it('does not fire without broad internal readability', () => {
+    expect(match('insider-bulk-exfil', [egress, blind])).toBeNull();
+  });
+});
+
+describe('undetected-compromise', () => {
+  it('fires when a real capability meets two or more detection gaps', () => {
+    const steps = match('undetected-compromise', [
+      f('guest-user-read-access'), // grants unauth-foothold
+      f('threat-detection-inactive'),
+      f('siem-integration-not-detected'),
+    ]);
+    expect(steps?.map((s) => s.id)).toContain('guest-user-read-access');
+    expect(steps?.map((s) => s.id)).toContain('threat-detection-inactive');
+  });
+
+  it('does not fire on a single detection gap', () => {
+    expect(match('undetected-compromise', [
+      f('guest-user-read-access'),
+      f('threat-detection-inactive'),
+    ])).toBeNull();
+  });
+
+  it('does not fire when no exploitable capability is present', () => {
+    expect(match('undetected-compromise', [
+      f('threat-detection-inactive'),
+      f('siem-integration-not-detected'),
+    ])).toBeNull();
+  });
+
+  it('ignores passed and inconclusive findings via the engine', () => {
+    const chains = new ChainEngine().correlate([
+      f('guest-user-read-access', { passed: true }),
+      f('threat-detection-inactive'),
+      f('siem-integration-not-detected'),
+    ]);
+    expect(chains.map((c) => c.id)).not.toContain('undetected-compromise');
+  });
+});
+
+describe('newly modelled capabilities', () => {
+  it.each([
+    ['separation-of-duties-self-escalation', 'org-takeover'],
+    ['separation-of-duties-code-and-data', 'code-exec'],
+    ['separation-of-duties-external-exfil-channel', 'external-egress'],
+    ['privileged-access-shadow-admins', 'org-takeover'],
+    ['flows-autolaunched-without-sharing', 'data-write'],
+    ['flows-screen-without-sharing', 'code-exec'],
+    ['public-group-sharing-exposure', 'data-read-bulk'],
+    ['report-folder-access-public', 'data-read'],
+    ['guest-record-access-policy-not-enforced', 'unauth-foothold'],
+    ['encryption-coverage-unencrypted-sensitive', 'data-read'],
+    ['sandbox-data-masking-pii-present', 'data-read'],
+  ])('%s grants %s', (id, cap) => {
+    expect(capabilitiesFor(f(id)).grants).toContain(cap);
+  });
+
+  it('a screen flow does not grant the unattended write an autolaunched flow does', () => {
+    expect(capabilitiesFor(f('flows-screen-without-sharing')).grants).not.toContain('data-write');
+  });
+
+  it('shadow admins now reach a named takeover chain that they previously could not', () => {
+    const chains = new ChainEngine().correlate([
+      f('guest-user-baseline'),
+      f('privileged-access-shadow-admins'),
+    ]);
+    expect(chains.map((c) => c.id)).toContain('standard-to-takeover');
+  });
+});

--- a/test/unit/chains/registryIntegrity.test.ts
+++ b/test/unit/chains/registryIntegrity.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { CAPABILITY_REGISTRY } from '../../../src/chains/CapabilityRegistry.js';
+
+/**
+ * Drift guard for the attack model.
+ *
+ * Both halves of the chain model reference findings by *string id*, and both fail silently when a
+ * string is wrong:
+ *
+ *   - a CAPABILITY_REGISTRY key that no check emits simply never grants anything, so the capability
+ *     it was meant to contribute is missing from every chain;
+ *   - a named-chain ingredient id that no check emits can never match, so that chain never fires.
+ *
+ * Neither shows up as a test failure anywhere else — the engine just quietly finds less. This test
+ * pins both directions against the ids the checks can actually produce.
+ *
+ * Ids are collected from the check implementations rather than by running them, because most ids
+ * are only emitted on specific org conditions that a unit test cannot reproduce in aggregate.
+ */
+
+const ROOT = process.cwd();
+const IMPL_DIR = join(ROOT, 'src/checks/impl');
+
+/** Literal finding ids, plus the static prefix of every template-literal id. */
+function collectEmittableIds(): { literals: Set<string>; prefixes: Set<string> } {
+  const literals = new Set<string>();
+  const prefixes = new Set<string>();
+  for (const file of readdirSync(IMPL_DIR).filter((f) => f.endsWith('.ts'))) {
+    const src = readFileSync(join(IMPL_DIR, file), 'utf8');
+    for (const m of src.matchAll(/\bid:\s*'([^']+)'/g)) literals.add(m[1]);
+    // `id: `foo-${bar}`` → the emittable ids all start with "foo-"
+    for (const m of src.matchAll(/\bid:\s*`([^`$]*)\$\{/g)) if (m[1]) prefixes.add(m[1]);
+    // `id: `foo-bar`` with no interpolation is just a literal
+    for (const m of src.matchAll(/\bid:\s*`([^`$]+)`/g)) literals.add(m[1]);
+  }
+  return { literals, prefixes };
+}
+
+/** Finding ids referenced as chain ingredients, i.e. inside byIds(...) / byPrefixes(...). */
+function collectChainReferencedIds(): Set<string> {
+  const src = readFileSync(join(ROOT, 'src/chains/namedChains.ts'), 'utf8');
+  const refs = new Set<string>();
+  for (const call of src.matchAll(/by(?:Ids|Prefixes)\(\s*\w+\s*,\s*\[([\s\S]*?)\]\s*\)/g)) {
+    for (const q of call[1].matchAll(/'([^']+)'/g)) refs.add(q[1]);
+  }
+  return refs;
+}
+
+const { literals, prefixes } = collectEmittableIds();
+
+describe('attack-model id integrity', () => {
+  it('collects a plausible number of finding ids from the checks', () => {
+    // Guards against the collectors silently matching nothing and the suite passing vacuously.
+    expect(literals.size).toBeGreaterThan(200);
+    expect(prefixes.size).toBeGreaterThan(5);
+  });
+
+  it('every CAPABILITY_REGISTRY key is a finding id some check can emit', () => {
+    const emittable = (id: string): boolean =>
+      literals.has(id) || [...prefixes].some((p) => id.startsWith(p));
+    const orphans = Object.keys(CAPABILITY_REGISTRY).filter((id) => !emittable(id));
+    expect(orphans).toEqual([]);
+  });
+
+  it('every named-chain ingredient id can be emitted by some check', () => {
+    // A chain may reference either a whole id or a prefix of a family of ids, so a reference is
+    // compatible if it matches a literal, extends a template prefix, or is extended by one.
+    const compatible = (id: string): boolean =>
+      literals.has(id) || [...prefixes].some((p) => id.startsWith(p) || p.startsWith(id));
+    const unreachable = [...collectChainReferencedIds()].filter((id) => !compatible(id));
+    expect(unreachable).toEqual([]);
+  });
+
+  it('finds chain ingredients at all', () => {
+    expect(collectChainReferencedIds().size).toBeGreaterThan(20);
+  });
+});

--- a/test/unit/checks/impl/AgentChannelExposureCheck.test.ts
+++ b/test/unit/checks/impl/AgentChannelExposureCheck.test.ts
@@ -122,8 +122,11 @@ describe('AgentChannelExposureCheck', () => {
     expect(JSON.stringify(crit[0])).toMatch(/Help Center/);
   });
 
-  // Fixture: agent + only internal channels (no guest sites, no public deployments).
-  it('emits an info finding for an agent on internal-only channels', async () => {
+  // Fixture: agent + a messaging channel, but no guest sites and no public deployments.
+  // Note this is "no public binding confirmed", NOT "internal-only": MessagingChannel also
+  // covers Messaging for In-App and Web, which is a public web surface, and nothing here ties
+  // an agent to a channel either way.
+  it('emits an info finding when no public channel binding could be confirmed', async () => {
     const ctx = makeCtx({
       agentAccess: 'ok',
       agentInventory: [agent()],
@@ -131,7 +134,7 @@ describe('AgentChannelExposureCheck', () => {
         if (/FROM Network/i.test(soql)) return Promise.resolve([]); // no live guest sites
         if (/FROM MessagingChannel/i.test(soql)) {
           return Promise.resolve([
-            { Id: 'MC1', MasterLabel: 'Internal SMS', ChannelType: 'Text', IsActive: true },
+            { Id: 'MC1', MasterLabel: 'Support SMS', MessageType: 'Text', PlatformType: 'Enhanced', IsActive: true },
           ]);
         }
         if (/FROM EmbeddedService/i.test(soql)) return Promise.resolve([]);
@@ -142,6 +145,90 @@ describe('AgentChannelExposureCheck', () => {
     expect(r.findings.some((f) => f.riskLevel === 'CRITICAL')).toBe(false);
     const info = r.findings.filter((f) => f.riskLevel === 'INFO');
     expect(info.length).toBeGreaterThanOrEqual(1);
+
+    // The channel count must not be dressed up as internal or authenticated reach. Creating a
+    // "Messaging for In-App and Web" channel also creates a MessagingChannel record, and that one
+    // is publicly reachable via the messaging API's unauthenticated guest token flow — so a
+    // blanket "internal / authenticated inbound surfaces" claim would under-report real exposure.
+    // The title must not assert internal-only reach...
+    expect(info[0].title).not.toMatch(/internal[- ]only/i);
+    // ...and the channel count must not be labelled internal or authenticated.
+    expect(info[0].detail).not.toMatch(/internal \/ authenticated/i);
+    // "internal-only" may appear in the detail, but only as the thing being ruled out.
+    for (const m of info[0].detail.matchAll(/internal[- ]only/gi)) {
+      const preceding = info[0].detail.slice(Math.max(0, m.index - 60), m.index);
+      expect(preceding).toMatch(/\bnot\b/i);
+    }
+    // A non-web channel (Text) is described accurately: external senders, not authenticated,
+    // but not a browser endpoint, and no exposure asserted because no binding exists.
+    expect(info[0].detail).toMatch(/non-web messaging channel/i);
+    expect(info[0].detail).toMatch(/Text/);
+    expect(info[0].detail).toMatch(/not\s+Salesforce-authenticated/i);
+    expect(info[0].detail).toMatch(/no queryable binding/i);
+  });
+
+  // Regression: the field is MessageType. Selecting a non-existent ChannelType raised
+  // INVALID_FIELD, which the surrounding catch swallowed — so every messaging channel silently
+  // vanished and the check could never see a web-type channel at all.
+  it('queries MessageType, never ChannelType', async () => {
+    const queries: string[] = [];
+    const ctx = makeCtx({
+      agentAccess: 'ok',
+      agentInventory: [agent()],
+      soql: (soql) => {
+        queries.push(soql);
+        return Promise.resolve([]);
+      },
+    });
+    await check.run(ctx);
+    const channelQuery = queries.find((q) => /FROM MessagingChannel/i.test(q));
+    expect(channelQuery).toBeDefined();
+    expect(channelQuery).toMatch(/MessageType/);
+    expect(channelQuery).not.toMatch(/ChannelType/);
+  });
+
+  // A web-type messaging channel is a browser-reachable surface, so it must be treated as a
+  // public channel candidate rather than counted as a benign internal one.
+  it.each(['EmbeddedMessaging', 'WebChat'])(
+    'treats a %s messaging channel as a public channel candidate',
+    async (messageType) => {
+      const ctx = makeCtx({
+        agentAccess: 'ok',
+        agentInventory: [agent()],
+        soql: (soql) => {
+          if (/FROM MessagingChannel/i.test(soql)) {
+            return Promise.resolve([
+              { Id: 'MC9', MasterLabel: 'Web Support', MessageType: messageType, PlatformType: 'Enhanced', IsActive: true },
+            ]);
+          }
+          return Promise.resolve([]);
+        },
+      });
+      const r = await check.run(ctx);
+      // No binding exists, so this is the honest MEDIUM "mapping unconfirmed" finding...
+      const medium = r.findings.filter((f) => f.riskLevel === 'MEDIUM');
+      expect(medium).toHaveLength(1);
+      expect(JSON.stringify(medium[0])).toMatch(/Web Support/);
+      // ...and it must NOT be reported as having no public channel.
+      expect(r.findings.some((f) => f.id === 'agent-channel-exposure-internal')).toBe(false);
+    },
+  );
+
+  it('does not treat an inactive web channel as public', async () => {
+    const ctx = makeCtx({
+      agentAccess: 'ok',
+      agentInventory: [agent()],
+      soql: (soql) => {
+        if (/FROM MessagingChannel/i.test(soql)) {
+          return Promise.resolve([
+            { Id: 'MC9', MasterLabel: 'Old Web', MessageType: 'EmbeddedMessaging', IsActive: false },
+          ]);
+        }
+        return Promise.resolve([]);
+      },
+    });
+    const r = await check.run(ctx);
+    expect(r.findings.some((f) => f.riskLevel === 'MEDIUM')).toBe(false);
   });
 
   // Fixture: active agents AND discovered public channels, but no resolvable binding

--- a/test/unit/compliance/catalog.test.ts
+++ b/test/unit/compliance/catalog.test.ts
@@ -1,4 +1,5 @@
 import { getControl, ALL_CONTROLS } from '../../../src/compliance/catalogs/index.js';
+import { packFrameworks } from '../../../src/compliance/resolve.js';
 
 describe('catalog lookup', () => {
   it('returns a control by id', () => {
@@ -18,10 +19,21 @@ describe('catalog lookup', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('contains the universal frameworks, SBS, and the NZ pack', () => {
+  it('contains the universal frameworks, SBS, the NZ pack, and HIPAA/GDPR', () => {
     const frameworks = new Set(ALL_CONTROLS.map((c) => c.framework));
-    for (const fw of ['OWASP', 'SOC2', 'ISO27001', 'SBS', 'HISO10029', 'PRIVACY_ACT', 'NZISM']) {
+    for (const fw of ['OWASP', 'OWASP_LLM', 'SOC2', 'ISO27001', 'SBS', 'HISO10029', 'PRIVACY_ACT',
+                      'NZISM', 'HIPAA', 'GDPR']) {
       expect(frameworks.has(fw as never)).toBe(true);
+    }
+  });
+
+  // Every framework named in the `all` pack must actually have controls behind it. Before the
+  // HIPAA/GDPR catalogs landed, both sat in the pack contributing nothing, so `--frameworks all`
+  // silently rendered zero rows for them.
+  it('every framework in the `all` pack has catalogued controls', () => {
+    const populated = new Set(ALL_CONTROLS.map((c) => c.framework));
+    for (const fw of packFrameworks('all')) {
+      expect(populated.has(fw)).toBe(true);
     }
   });
 

--- a/test/unit/compliance/regulatoryCatalogs.test.ts
+++ b/test/unit/compliance/regulatoryCatalogs.test.ts
@@ -1,0 +1,108 @@
+import { CHECK_CONTROL_MAP } from '../../../src/compliance/mapping.js';
+import { ALL_CONTROLS, getControl } from '../../../src/compliance/catalogs/index.js';
+import { HIPAA_CONTROLS } from '../../../src/compliance/catalogs/hipaa.js';
+import { GDPR_CONTROLS } from '../../../src/compliance/catalogs/gdpr.js';
+import { resolveControls, resolveFrameworks } from '../../../src/compliance/resolve.js';
+import { CHECKS } from '../../../src/checks/registry.js';
+
+/**
+ * HIPAA and GDPR were listed in the `Framework` union and in the `all` pack long before they had
+ * catalogs, so `--frameworks all` and `--frameworks hipaa` resolved to zero rendered controls.
+ * These tests pin the properties that made that state detectable, so it cannot recur silently.
+ */
+
+describe('HIPAA catalog', () => {
+  it('pins the operative Security Rule, not the 2025 proposed rewrite', () => {
+    for (const c of HIPAA_CONTROLS) {
+      expect(c.framework).toBe('HIPAA');
+      expect(c.version).toBe('45 CFR Part 164 Subpart C (HIPAA Security Rule, 2013 Omnibus)');
+    }
+  });
+
+  it('cites a real CFR paragraph for every control', () => {
+    for (const c of HIPAA_CONTROLS) {
+      expect(c.sourceRef).toMatch(/^45 CFR 164\.3(08|10|12|16)\([a-e]\)/);
+      expect(c.id).toBe(`HIPAA-${c.sourceRef.replace('45 CFR ', '')}`);
+    }
+  });
+
+  it('keeps the Required/Addressable designation on specs that carry one', () => {
+    const byId = new Map(HIPAA_CONTROLS.map((c) => [c.id, c]));
+    expect(byId.get('HIPAA-164.312(a)(2)(i)')?.title).toContain('(Required)');
+    expect(byId.get('HIPAA-164.312(a)(2)(iv)')?.title).toContain('(Addressable)');
+    expect(byId.get('HIPAA-164.308(a)(1)(ii)(A)')?.title).toContain('(Required)');
+    // Standards themselves are neither, so they must not be labelled.
+    expect(byId.get('HIPAA-164.312(b)')?.title).not.toMatch(/Required|Addressable/);
+  });
+});
+
+describe('GDPR catalog', () => {
+  it('pins the regulation and cites an article or paragraph', () => {
+    for (const c of GDPR_CONTROLS) {
+      expect(c.framework).toBe('GDPR');
+      expect(c.version).toBe('Regulation (EU) 2016/679');
+      expect(c.sourceRef).toMatch(/^Regulation \(EU\) 2016\/679, Art\. \d+/);
+    }
+  });
+
+  it('maps paragraphs, not whole articles, where the obligation is a paragraph', () => {
+    const ids = GDPR_CONTROLS.map((c) => c.id);
+    expect(ids).toContain('GDPR-Art5(1)(f)');
+    expect(ids).toContain('GDPR-Art32(1)(a)');
+    expect(ids).toContain('GDPR-Art32(1)(b)');
+    expect(ids).toContain('GDPR-Art32(1)(d)');
+    // Art. 32 as a bare article would be too coarse to cite against a finding.
+    expect(ids).not.toContain('GDPR-Art32');
+  });
+});
+
+describe('regulatory mapping', () => {
+  it('maps every registered check to at least one HIPAA and one GDPR control', () => {
+    const missing: string[] = [];
+    for (const check of CHECKS) {
+      const ids = CHECK_CONTROL_MAP[check.id] ?? [];
+      if (!ids.some((i) => i.startsWith('HIPAA-'))) missing.push(`${check.id} (HIPAA)`);
+      if (!ids.some((i) => i.startsWith('GDPR-'))) missing.push(`${check.id} (GDPR)`);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('leaves no catalogued HIPAA/GDPR control unmapped', () => {
+    const mapped = new Set(Object.values(CHECK_CONTROL_MAP).flat());
+    const orphans = ALL_CONTROLS
+      .filter((c) => c.framework === 'HIPAA' || c.framework === 'GDPR')
+      .filter((c) => !mapped.has(c.id))
+      .map((c) => c.id);
+    expect(orphans).toEqual([]);
+  });
+
+  it('never lists the same control twice for one check', () => {
+    for (const [check, ids] of Object.entries(CHECK_CONTROL_MAP)) {
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(check).toMatch(/.+/);
+    }
+  });
+
+  it('resolves HIPAA and GDPR through the provenance gate', () => {
+    // Both catalogs are source-verified, so they must survive requireVerified.
+    const hipaa = resolveControls('encryption-coverage', { frameworks: ['HIPAA'] });
+    expect(hipaa.length).toBeGreaterThan(0);
+    expect(hipaa.every((c) => c.verified)).toBe(true);
+
+    const gdpr = resolveControls('sandbox-data-masking', { frameworks: ['GDPR'] });
+    expect(gdpr.map((c) => c.id)).toContain('GDPR-Art32(1)(a)');
+  });
+
+  it('the hipaa and gdpr --frameworks aliases resolve', () => {
+    expect(resolveFrameworks('hipaa')).toEqual(['HIPAA']);
+    expect(resolveFrameworks('gdpr')).toEqual(['GDPR']);
+    expect(resolveFrameworks('hipaa,gdpr')).toEqual(['HIPAA', 'GDPR']);
+  });
+
+  it('scopes the agent checks to HIPAA/GDPR even though the NZ pack has no chapter for them', () => {
+    const ids = CHECK_CONTROL_MAP['agent-user-privilege'] ?? [];
+    expect(ids).toContain('HIPAA-164.312(a)(1)');
+    expect(ids).toContain('GDPR-Art32(1)(b)');
+    expect(getControl('HIPAA-164.312(a)(1)')?.title).toBe('Access control');
+  });
+});

--- a/test/unit/docs/readme-chain-list.test.ts
+++ b/test/unit/docs/readme-chain-list.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NAMED_CHAINS } from '../../../src/chains/namedChains.js';
+
+/**
+ * Documentation-drift guard for the README's "Attack chains" section.
+ *
+ * The same guard the check count gets (`readme-check-count.test.ts`), for the same reason: the
+ * README advertises the named chains to clients, and a list that silently falls behind
+ * `namedChains.ts` is worse than no list — it describes an audit the tool no longer performs.
+ *
+ * Pins three things against NAMED_CHAINS:
+ *   1. the table lists exactly one row per named chain,
+ *   2. every chain's title and severity appear, spelled the same way as in code,
+ *   3. the prose count ("The eleven named chains") matches too.
+ */
+
+const ROOT = process.cwd();
+const README = readFileSync(join(ROOT, 'README.md'), 'utf8');
+
+/** The "## Attack chains" section, which must sit outside the check-count guard's range. */
+function chainSection(): string {
+  const from = README.indexOf('## Attack chains');
+  const to = README.indexOf('## Scope & Liability');
+  expect(from).toBeGreaterThanOrEqual(0);
+  expect(to).toBeGreaterThan(from);
+  return README.slice(from, to);
+}
+
+function chainTableRows(): string[] {
+  return chainSection()
+    .split('\n')
+    .filter((l) => l.startsWith('| '))
+    .filter((l) => !/^\|\s*(Chain\b|:?-{2,})/.test(l));
+}
+
+const NUMBER_WORDS: Record<number, string> = {
+  8: 'eight', 9: 'nine', 10: 'ten', 11: 'eleven', 12: 'twelve', 13: 'thirteen', 14: 'fourteen',
+};
+
+describe('README attack-chain list stays in sync with namedChains.ts', () => {
+  it('lists exactly one table row per named chain', () => {
+    expect(chainTableRows()).toHaveLength(NAMED_CHAINS.length);
+  });
+
+  it('documents every chain title and its severity', () => {
+    const section = chainSection();
+    for (const chain of NAMED_CHAINS) {
+      expect(section).toContain(chain.title);
+      // The title and severity must be on the same row, not merely both present somewhere.
+      const row = chainTableRows().find((l) => l.includes(chain.title));
+      expect(row).toBeDefined();
+      expect(row).toContain(chain.severity);
+    }
+  });
+
+  it('states the chain count correctly in prose', () => {
+    const word = NUMBER_WORDS[NAMED_CHAINS.length];
+    expect(word).toBeDefined(); // extend NUMBER_WORDS if this fires
+    expect(README).toContain(`The ${word} named chains`);
+    expect(README).toContain(`${word} modelled chains`);
+  });
+
+  it('keeps the chain table out of the check-count guard\'s range', () => {
+    // readme-check-count counts every "| " row between these two headings, so an attack-chain
+    // table placed there would be counted as checks and break that test instead of this one.
+    const checksFrom = README.indexOf('## What It Checks');
+    const complianceFrom = README.indexOf('## Compliance frameworks');
+    const chainsFrom = README.indexOf('## Attack chains');
+    expect(chainsFrom).toBeGreaterThan(checksFrom);
+    expect(chainsFrom).toBeGreaterThan(complianceFrom);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    // Required by the NodeNext module kind; also silences ts-jest TS151002.
+    // Required by the NodeNext module kind. Also matches how the test transform behaves:
+    // swc strips types per-file with no cross-file type info, so anything isolatedModules
+    // rejects would compile differently under jest than under tsc.
     "isolatedModules": true,
     "lib": ["ES2022"]
   },


### PR DESCRIPTION
Five logically separate changes, split so the one genuine bug fix is reviewable and revertable on its own.

## `fix` — MessagingChannel was never readable (review this first)

`MessagingChannel` has no `ChannelType` field; it is **`MessageType`**. Selecting `ChannelType` failed with `INVALID_FIELD`, the surrounding `catch` returned `[]`, and `messagingChannels` was therefore **always empty in every org**. The check could never see a messaging channel and always took the "no channels discovered" branch. A defensive catch meant to tolerate a missing object was masking a schema error instead.

Confirmed against a live org describe. `MessageType` has 22 values, of which `EmbeddedMessaging` and `WebChat` are browser-reachable; the rest (`Text`, `Phone`, `WhatsApp`, `Facebook`, voice variants, …) are not web endpoints.

Web-type channels now become public channel candidates, raising the honest MEDIUM "mapping unconfirmed" finding instead of being counted as benign internal surfaces. **Exposure is still never asserted** — no queryable binding ties an agent to a channel, so a bound agent cannot be claimed either way.

Also corrects reporting that called every channel an "internal / authenticated inbound surface" inside a finding titled "internal-only channels". Neither was true: SMS and WhatsApp senders hold a phone number or account handle, not Salesforce credentials.

> The old fixture used `ChannelType: 'Text'` — a field that does not exist — which is why the suite never caught this. There is now a regression guard on the query string itself.

**Behaviour change:** orgs with an active `EmbeddedMessaging` or `WebChat` channel and active agents will now see a MEDIUM finding they did not see before.

## `feat(compliance)` — HIPAA and GDPR catalogs

Both were already in the `Framework` union and the `all` pack but had no catalogs, so `--frameworks all` and `--frameworks hipaa` rendered zero controls. Adds 26 controls (93 → 119).

- **HIPAA (18)** — 45 CFR 164.308 administrative and 164.312 technical safeguards, preserving each spec's Required/Addressable designation. Pins the **operative** rule: the HHS NPRM of 2025-01-06 would delete that distinction and mandate encryption/MFA/segmentation, but as of 2026-08 it is still *proposed*. A test asserts the pinned version string so a careless bump fails loudly.
- **GDPR (8)** — Art. 5(1)(f), 25, 30, 32(1)(a)/(b)/(d), 33, 44, mapped at **paragraph** level so a finding cites the specific obligation rather than "Article 32" at large.

Out-of-scope articles and safeguards (physical safeguards, contingency planning, DPIAs, lawful basis) are deliberately absent, and the catalogs say so — absence is not a claim they don't apply.

**Mapping refactor:** extracts domain check-lists into a shared `DOMAIN` object that both `NZ_CROSSWALK` and the new `REGULATORY_CROSSWALK` read from, so the two cannot drift. Controls narrower than a domain go in `REGULATORY_PRECISE` per check — sweeping "automatic logoff" across all fourteen authentication checks would be exactly the imprecision a sourced catalog exists to avoid.

Verified behaviour-preserving rather than asserted: dumped the mapping from `HEAD`, dumped it from the new code, stripped HIPAA/GDPR ids, diffed — **all 88 checks byte-identical**.

Neither framework joins a named pack; jurisdiction is the user's call.

Also closes a pre-existing worksheet gap: the OWASP LLM section was missing entirely, so the total read 89 against an actual 93.

## `feat(chains)` — capability coverage 30 → 43 of 88 checks

Several gaps were hard to defend — `separation-of-duties`, whose own combos are named `self-escalation`, `identity-takeover` and `external-exfil-channel`, contributed nothing to the chain engine.

14 new grants, each mirroring an existing precedent rather than inventing semantics. Deliberate asymmetries: screen flows get no `data-write` (a user must drive them); `public-group-sharing` grants `data-read-bulk` but no entry point, being internal by definition.

**Granting a capability turned out to be only half the wiring.** Chains match on explicit id lists, so `privileged-access-shadow-admins` opened the `standard-to-takeover` gate but hit the `steps >= 2` floor and never fired. Five existing chains now include the new findings.

Three new chains: `sandbox-pii-exposure`, `insider-bulk-exfil`, `undetected-compromise` (the last requires **two or more** detection gaps, so it doesn't fire on every org that hasn't bought Shield).

**Guest chains now name the actual request path** — `/s/sfsites/aura` with `aura.token=null`, `RecordUiController/ACTION$executeGraphQL`, `aura.ApexAction.execute` — and state that no credentials are in the path, so MFA, IP ranges and SSO never engage. The instinctive remediation does nothing here.

The Agentforce chain names a **different** transport, verified rather than assumed: agent conversations go to the messaging host over the Messaging for In-App and Web API, whose unauthenticated guest token flow needs only the org id and the deployment's `esDeveloperName`. It does **not** traverse Aura. Tests pin both vectors as distinct so one sentence copied between them can't make both wrong. Narratives stop short of copy-pasteable exploit bodies, since they render into a client-facing report.

`registryIntegrity.test` closes a hole the registry comment already claimed was covered: it fails on a registry key nothing emits, or a chain ingredient nothing emits. Both were silent failures. All 52 keys and 61 ingredients currently resolve, so nothing was already broken.

## `docs` — README 935 → 459 lines

Moved into `docs/` rather than deleted: `COMMANDS.md` (the four non-audit commands; forensic timeline alone was 162 lines), `SCORING.md`, `TRUST.md`, `FURTHER-READING.md`. What stayed is the test-enforced reference content people come for.

New **Attack chains** section documenting all eleven. Placement is load-bearing: `readme-check-count` counts every table row between "What It Checks" and "Compliance frameworks", so a chain table there would have been counted as 11 extra checks. `readme-chain-list.test` now pins one row per chain, title and severity on the same row, the prose count, and that the table stays outside that range.

Stale claims corrected: the read-only guarantee cited `src/api/*ClientImpl.ts` (gone — moved into `@cclabsnz/sf-core`); the "monorepo" claim was false; the `socket.yml` link 404'd; and the URL-audit claim promised "seven results, every one a standards-body link" when it now prints ten. A reader following those instructions to verify the trust claim would have found three unexplained URLs.

## `chore(deps)` — drop dead `ts-node`

Verified unused rather than assumed: hid it from `node_modules`, confirmed `jest --showConfig` still parsed `jest.config.ts` with the swc transform intact, ran the suite green. Jest 30 parses TS configs natively.

Also refreshes an install that was stale against the lockfile.

## Verification

- `npm run build`, `npm run typecheck`, `npm test` all exit 0 — **90 suites / 683 tests** (from 85 / 629)
- `pnpm audit`: 0 advisories
- Ran the `guard-internal-files` grep locally: no agent or secret-shaped files tracked
- The tip is verified; intermediate commits were not individually test-run

## Note on sourcing

The compliance catalogs are sourced from primary text (codified CFR, consolidated regulation). The Agentforce messaging endpoints are corroborated across the official authorization guide plus several secondary sources — `developer.salesforce.com` is SPA-rendered, so the endpoint tables could not be extracted directly. Worth spot-checking `esDeveloperName` against a live deployment before that narrative reaches a client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
