### PR TITLE
chore(ci): install the pinned npm with --ignore-scripts, assert the version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,11 +56,25 @@ jobs:
       # Pinned, not `@latest`. This step runs in the job that holds the OIDC token, so an
       # unpinned global install hands whatever npm published in the last hour a credential
       # that can publish this package. 12.0.2 is the version the 1.7.0 release used.
+      #
+      # `--ignore-scripts` closes the remaining window: a global install runs lifecycle
+      # scripts, and here they would execute alongside a credential that can publish this
+      # package. npm needs no install scripts to work, so nothing is lost. (Scorecard's
+      # Pinned-Dependencies alert wants a hash instead, which npm cannot do for a global
+      # install — this is the security fix, not a way to clear that alert.)
+      #
+      # The version is then asserted rather than merely echoed. This workflow runs only on a
+      # published release, so a silently failed upgrade would otherwise surface as a broken
+      # publish at the worst moment; failing here is cheap and loud.
       - name: Upgrade npm (>= 11.5.1 required for OIDC trusted publishing)
         run: |
-          npm install -g npm@12.0.2
+          npm install -g npm@12.0.2 --ignore-scripts
           echo "node: $(node -v)"
           echo "npm:  $(npm -v)  (path: $(which npm))"
+          if [ "$(npm -v)" != "12.0.2" ]; then
+            echo "::error::npm upgrade did not take: expected 12.0.2, got $(npm -v)"
+            exit 1
+          fi
 
       - name: Publish to npm with provenance (OIDC trusted publishing)
         run: |


### PR DESCRIPTION
Hardens the one step in `publish.yml` that runs while the job holds the OIDC publish credential.

## What and why

`npm install -g npm@12.0.2` was already pinned, which stops an unpinned install handing a freshly-published tarball a credential that can publish this package. But a global install still **executes lifecycle scripts**, and those would run next to that credential. npm needs no install scripts here, so `--ignore-scripts` closes the remaining window at no cost.

The step also now **asserts** the resulting version rather than only echoing it:

```yaml
npm install -g npm@12.0.2 --ignore-scripts
...
if [ "$(npm -v)" != "12.0.2" ]; then
  echo "::error::npm upgrade did not take: expected 12.0.2, got $(npm -v)"
  exit 1
fi
```

This matters because `publish.yml` runs **only on a published release**. An upgrade that silently failed would otherwise surface as a broken publish at the worst possible moment. Failing the step is cheap and loud.

## This does not clear the Scorecard alert

Scorecard's `Pinned-Dependencies` (#20) wants the npm command pinned **by hash**, which npm cannot do for a global install. The score stays 8/10 either way. This is the security fix, not the score fix — the alert is being dismissed separately as won't-fix.

## Verification note

`publish.yml` cannot be dry-run: its only triggers are `release: [published]` and `workflow_dispatch`, and **both publish to npm**. So this change is deliberately not exercised before merge — which is precisely why the version assertion was added rather than trusting the install to succeed.

What was verified: the workflow YAML parses (10 steps, triggers unchanged), and the `run` block is shell-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
