### PR TITLE
docs(contributing): state the testing policy, fix the stale inventory pointer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,17 +48,30 @@ A new check is five touch points:
 2. Registration in `src/checks/registry.ts` (order matters: a check's
    `dependsOnCache` must be satisfied by an earlier check's `populatesCache`;
    `CheckEngine.validateCacheOrdering()` enforces this at startup).
-3. A compliance mapping entry in `src/compliance/mapping.ts`.
+3. A compliance mapping entry in `src/compliance/mapping.ts` — add the check id to
+   `BASE_CHECK_CONTROL_MAP` **and** to the right `DOMAIN` group, which is what earns it
+   the NZ-pack and HIPAA/GDPR controls in one step.
 4. A `CHECK_META` entry (effort + impact) in `src/findings/CheckMeta.ts`.
 5. A unit test in `test/unit/checks/impl/` with mocked clients.
 
-Then update the check count and the "What It Checks" table in `README.md`. It is
-the source-of-truth listing.
+Then update the inventory in `docs/CHECKS.md` (the source-of-truth listing) and the
+per-domain summary in `README.md`. Both are enforced: `readme-check-count.test.ts`
+fails the build if either drifts from `src/checks/registry.ts`.
+
+## Testing policy
+
+**Every change that adds or alters behaviour ships with automated tests in the same pull
+request.** New checks require a unit test with mocked SOQL/Tooling/REST clients; bug fixes
+require a test that fails without the fix. Documentation-only changes are exempt, though
+the counts and tables in `README.md` and `docs/` are themselves test-enforced.
+
+This is not advisory: `build-test` is a required status check on `main`, so a pull request
+whose tests do not pass cannot merge.
 
 ## Before you open a pull request
 
 - `npm run build` is clean.
-- `npm test` is green (typecheck + Jest, ESM). New/changed checks ship with unit tests.
+- `npm test` is green (typecheck + Jest, ESM). New/changed behaviour ships with unit tests.
 - Registry ordering still validates and every new check id has a compliance
   mapping and `CHECK_META` entry.
 - README counts/flags are updated if user-facing behaviour changed.


### PR DESCRIPTION
Groundwork for the OpenSSF Best Practices badge, plus a stale pointer the README restructure left behind.

**Testing policy.** The `test_policy` criterion requires a stated policy that major new functionality ships with tests. That expectation existed only as one line in the PR checklist, scoped to checks. Now stated generally — new behaviour needs tests, bug fixes need a test that fails without the fix, docs-only changes are exempt — and noted as enforced rather than advisory, since `build-test` is a required check on `main`.

**Stale pointer.** #77 moved the check inventory to `docs/CHECKS.md`, but CONTRIBUTING still told contributors the README table was the source-of-truth listing. Now points at both the inventory and the per-domain summary, and notes `readme-check-count.test.ts` fails the build if either drifts.

**Mapping step.** Expanded to say the check id must go in a `DOMAIN` group as well as `BASE_CHECK_CONTROL_MAP` — that is what earns it NZ-pack and HIPAA/GDPR controls, and missing it fails `regulatoryCatalogs.test`.

Docs only; `npm test` green (90 suites / 685 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)