### PR TITLE
chore: remove dead code, make unused declarations a compile error

### DIFF
--- a/src/checks/impl/ApexCrudFLSCheck.ts
+++ b/src/checks/impl/ApexCrudFLSCheck.ts
@@ -12,7 +12,6 @@ const HAS_FLS = /(?:\.isAccessible\(\)|\.isCreateable\(\)|\.isUpdateable\(\)|\.i
 // Classes that are exempt from CRUD/FLS enforcement by design:
 // batch, scheduled, and trigger handlers run in a system context
 const IS_BATCH_OR_SCHEDULED = /implements\s+(?:Database\.Batchable|Schedulable|Database\.StatefulBatch|Database\.AllowsCallouts)/i;
-const IS_TEST = /@IsTest\b/i;
 const WITHOUT_SHARING = /\bwithout\s+sharing\b/i;
 
 export class ApexCrudFLSCheck implements SecurityCheck {
@@ -44,8 +43,9 @@ export class ApexCrudFLSCheck implements SecurityCheck {
     const withoutSharingNoFls: string[] = [];
     const withDmlNoFls: string[] = [];
 
-    // apexBodies is pre-filtered by HardcodedCredentialsCheck to exclude test classes;
-    // IS_TEST guard here is redundant but kept for cache-miss safety
+    // apexBodies is pre-filtered by HardcodedCredentialsCheck, which excludes @IsTest classes
+    // before populating the cache. There is deliberately no second guard here: a cache miss
+    // yields an empty array, not unfiltered bodies, so there is nothing for one to catch.
     for (const { name, body } of apexBodies) {
       if (!body || IS_BATCH_OR_SCHEDULED.test(body)) continue;
 

--- a/src/checks/impl/ApexRestEndpointCheck.ts
+++ b/src/checks/impl/ApexRestEndpointCheck.ts
@@ -7,10 +7,6 @@ const WITHOUT_SHARING_RE = /\bwithout\s+sharing\b/i;
 const NO_SHARING_DECLARED_RE = /\b(with|without|inherited)\s+sharing\b/i;
 const IS_TEST_RE = /@IsTest\b/i;
 
-// Indicators that the endpoint performs some form of caller verification
-const AUTH_CHECK_RE = /(?:RestContext\.request\.headers\.get|UserInfo\.getUserId\(\)|UserInfo\.getOrganizationId\(\)|Auth\.AuthConfiguration|isPortalEnabled\(\)|getSessionId\(\))/i;
-const GUEST_VISIBLE_RE = /(@HttpGet|@HttpPost|@HttpPut|@HttpDelete|@HttpPatch)/i;
-
 export class ApexRestEndpointCheck implements SecurityCheck {
   readonly id = 'apex-rest-endpoint';
   readonly name = 'Apex REST Endpoint Security';

--- a/src/checks/impl/ApexSharingCheck.ts
+++ b/src/checks/impl/ApexSharingCheck.ts
@@ -3,13 +3,6 @@ import type { SecurityCheck, CheckResult } from '../SecurityCheck.js';
 import type { Finding } from '../../findings/Finding.js';
 import { ApexRepository } from '@cclabsnz/sf-core';
 
-interface ApexClassRecord {
-  Id: string;
-  Name: string;
-  Body: string;
-  NamespacePrefix: string | null;
-}
-
 const INHERITED_SHARING = /\binherited\s+sharing\b/i;
 const WITHOUT_SHARING = /\bwithout\s+sharing\b/i;
 const WITH_SHARING = /\bwith\s+sharing\b/i;

--- a/src/checks/impl/CodeSecurityCheck.ts
+++ b/src/checks/impl/CodeSecurityCheck.ts
@@ -7,10 +7,6 @@ interface ApexCoverageRecord {
   PercentCovered: number;
 }
 
-interface CountResult {
-  expr0?: number;
-}
-
 // SBS-CODE-002: dynamic SOQL with string concatenation is the primary SOQL injection vector.
 // Pattern: Database.query( or Database.countQuery( followed by a + operator before the closing paren/semicolon.
 const DYNAMIC_SOQL_INJECTION = /Database\.(query|countQuery)\s*\([^;)]*\+[^;)]*[);]/gi;

--- a/src/checks/impl/GuestExecutableApexCheck.ts
+++ b/src/checks/impl/GuestExecutableApexCheck.ts
@@ -5,7 +5,6 @@ import { ApexRepository } from '@cclabsnz/sf-core';
 
 interface GuestUser { Id: string; ProfileId: string; Username: string; }
 interface SetupAccess { SetupEntityId: string; ParentId: string; }
-interface ApexName { Id: string; Name: string; }
 
 const WITHOUT_SHARING = /\bwithout\s+sharing\b/i;
 const WITH_SHARING = /\bwith\s+sharing\b/i;

--- a/src/checks/impl/HardcodedCredentialsCheck.ts
+++ b/src/checks/impl/HardcodedCredentialsCheck.ts
@@ -3,14 +3,6 @@ import type { SecurityCheck, CheckResult } from '../SecurityCheck.js';
 import type { Finding } from '../../findings/Finding.js';
 import { ApexRepository } from '@cclabsnz/sf-core';
 
-interface ApexClassRecord {
-  Id: string;
-  Name: string;
-  Body: string;
-  LengthWithoutComments: number;
-  NamespacePrefix: string | null;
-}
-
 const HIGH_RISK_PATTERNS = [
   /Bearer\s+[A-Za-z0-9\-_.~+/]{20,}=*/gi,        // Bearer tokens (min length to avoid test stubs)
   /Basic\s+[A-Za-z0-9+/]{20,}=*/gi,               // Basic auth (min length)
@@ -64,7 +56,6 @@ export class HardcodedCredentialsCheck implements SecurityCheck {
 
     const namedCredentialEndpoints = (ctx.cache.namedCredentialEndpoints ?? []).filter(Boolean);
     const remoteSiteUrls = (ctx.cache.remoteSiteUrls ?? []).filter(Boolean);
-    const allCoveredEndpoints = [...namedCredentialEndpoints, ...remoteSiteUrls];
 
     const classesWithCredentials: string[] = [];
     const classesWithRawEndpointsUncovered: string[] = [];

--- a/src/checks/impl/InternalUserMfaCheck.ts
+++ b/src/checks/impl/InternalUserMfaCheck.ts
@@ -22,7 +22,6 @@ export class InternalUserMfaCheck implements SecurityCheck {
   async run(ctx: AuditContext): Promise<CheckResult> {
     const findings: Finding[] = [];
     const baseUrl = ctx.orgInfo.instanceUrl;
-    const setupUrl = `${baseUrl}/lightning/setup/EnhancedProfiles/home`;
 
     // queryAll to avoid LIMIT 500 truncation — PSA query below fetches all records,
     // so a truncated user list would produce false-pass results for the missing users.

--- a/src/checks/impl/NamedCredentialsCheck.ts
+++ b/src/checks/impl/NamedCredentialsCheck.ts
@@ -15,11 +15,6 @@ interface NamedCredentialRecord {
   PrincipalType: string | null;
 }
 
-interface ApexClassRecord {
-  Name: string;
-  Body: string;
-}
-
 export class NamedCredentialsCheck implements SecurityCheck {
   readonly id = 'named-credentials';
   readonly name = 'Named Credentials';

--- a/src/checks/impl/ScheduledApexCheck.ts
+++ b/src/checks/impl/ScheduledApexCheck.ts
@@ -28,7 +28,6 @@ export class ScheduledApexCheck implements SecurityCheck {
     const findings: Finding[] = [];
     const baseUrl = ctx.orgInfo.instanceUrl;
     const apexJobsUrl = `${baseUrl}/lightning/setup/ScheduledJobs/home`;
-    const apexClassesUrl = `${baseUrl}/lightning/setup/ApexClasses/home`;
 
     // Query all active scheduled/batch Apex jobs
     const jobs = await ctx.soql.queryAll<ApexJobRecord>(`

--- a/src/checks/impl/SsoEnforcementCheck.ts
+++ b/src/checks/impl/SsoEnforcementCheck.ts
@@ -19,7 +19,6 @@ export class SsoEnforcementCheck implements SecurityCheck {
   async run(ctx: AuditContext): Promise<CheckResult> {
     const findings: Finding[] = [];
     const baseUrl = ctx.orgInfo.instanceUrl;
-    const setupUrl = `${baseUrl}/lightning/setup/SingleSignOn/home`;
 
     try {
       // Single query: recent credential logins over the past 30 days.

--- a/src/renderers/HtmlRenderer.ts
+++ b/src/renderers/HtmlRenderer.ts
@@ -199,7 +199,7 @@ export class HtmlRenderer implements AuditRenderer {
       .map((c) => {
         const conf = c.confidence === 'named' ? '' : ' (potential)';
         const steps = c.steps
-          .map((s, i) => `<li><strong>${escStr(s.title ?? s.findingId)}</strong> (${escStr(s.severity ?? '—')}): grants <code>${escStr(s.capability)}</code></li>`)
+          .map((s) => `<li><strong>${escStr(s.title ?? s.findingId)}</strong> (${escStr(s.severity ?? '—')}): grants <code>${escStr(s.capability)}</code></li>`)
           .join('');
         return `<div class="attack-chain severity-${c.severity.toLowerCase()}">
   <h3>[${escStr(c.severity)}] ${escStr(c.title)}${conf}</h3>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,11 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
+    // Dead code is a review burden and hides abandoned intent, so unused locals,
+    // parameters and switch fallthrough are compile errors, not warnings.
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Enables `noUnusedLocals`, `noUnusedParameters` and `noFallthroughCasesInSwitch`, and clears the 13 findings that surfaced. Net **-28 lines** across 12 files.

Found while assessing the repo against the OpenSSF Best Practices criteria. `strict: true` already satisfied the `warnings` criterion, so this isn't needed for the badge — it's worth doing on its own merits.

## Two of these were abandoned intent, not cruft

**`ApexRestEndpointCheck`** declared `AUTH_CHECK_RE` and `GUEST_VISIBLE_RE` under the comment *"Indicators that the endpoint performs some form of caller verification"* — and never used them. The check therefore treats every `@RestResource` class running `without sharing` alike, whether or not it verifies its caller.

Removing the constants changes no behaviour; it stops the file implying a capability that was never built. **The gap itself is a separate decision** — implementing that distinction would reduce false positives on endpoints that do check their caller. Flagging rather than silently deleting the evidence.

**`ApexCrudFLSCheck`** declared `IS_TEST` beneath a comment claiming an *"IS_TEST guard here is redundant but kept for cache-miss safety"*. There was no guard — the constant was unused. The upstream filtering is real (`HardcodedCredentialsCheck` excludes `@IsTest` classes before populating `apexBodies`), so behaviour was always correct, but a comment describing a safety net that doesn't exist is worse than the dead constant. The comment now states what actually happens: a cache miss yields an empty array, not unfiltered bodies, so there is nothing a local guard could catch.

## The rest are genuine leftovers

- Four unused type declarations stranded when the Apex queries moved to sf-core's `ApexRepository` (`ApexClassRecord` in three files, `CountResult`, `ApexName`)
- `allCoveredEndpoints` in `HardcodedCredentialsCheck`, which merged the named-credential and remote-site lists while the code correctly tests coverage against **each source separately** — the merged array was never the right shape
- Three computed-but-unused setup URLs. Checked first: the findings link to user records and job pages instead, so no finding lost its link
- An unused map index in `HtmlRenderer`

## Verification

- `build`, `typecheck`, `test` all exit 0 — **90 suites / 685 tests**
- Negative-tested: adding an unused private field fails typecheck with `TS6133`, so the guard bites on new dead code rather than passing vacuously

🤖 Generated with [Claude Code](https://claude.com/claude-code)