### PR TITLE
test: cover untested checks; stop three checks reporting a pass they cannot support

### DIFF
--- a/src/checks/impl/FieldLevelSecurityCheck.ts
+++ b/src/checks/impl/FieldLevelSecurityCheck.ts
@@ -75,6 +75,7 @@ export class FieldLevelSecurityCheck implements SecurityCheck {
     const sfIdPattern = /^[A-Za-z0-9]{15,18}$/;
     const objectApiNameById = new Map<string, string>();
 
+    let entityLookupFailed = false;
     const customObjectIds: string[] = [];
     for (const field of sensitiveFields) {
       const teo = field.TableEnumOrId;
@@ -95,7 +96,9 @@ export class FieldLevelSecurityCheck implements SecurityCheck {
           objectApiNameById.set(e.Id, e.QualifiedApiName);
         }
       } catch {
-        // If entity lookup fails, custom object field names will be unresolvable
+        // Recorded, not swallowed: without these names the fields cannot be analysed, and a
+        // silent failure here previously surfaced as a clean pass.
+        entityLookupFailed = true;
       }
     }
 
@@ -109,16 +112,21 @@ export class FieldLevelSecurityCheck implements SecurityCheck {
       }
     }
 
+    const unresolvedCount = sensitiveFields.length - fieldApiNames.length;
+
     if (fieldApiNames.length === 0) {
       findings.push({
-        id: 'field-level-security-ok',
+        id: 'field-level-security-unresolved',
         category: this.category,
-        riskLevel: 'LOW',
-        passed: true,
-        title: 'Sensitive custom fields appear appropriately restricted',
-        detail: 'No sensitive custom fields with excessive permission set access were found.',
+        riskLevel: 'INFO',
+        inconclusive: true,
+        title: `Field-level security could not be evaluated for ${sensitiveFields.length} sensitive field(s)`,
+        detail:
+          `${sensitiveFields.length} sensitive custom field(s) were found, but their object API names could not be resolved` +
+          `${entityLookupFailed ? ' because the EntityDefinition lookup was not accessible' : ''}. ` +
+          'Field-level security was therefore not evaluated for any of them. This is an incomplete result, not a clean one.',
         remediation:
-          'Continue to apply restrictive field-level security to any new sensitive fields.',
+          'Grant the audit user access to the Tooling API EntityDefinition object and re-run, then review field-level security on the reported fields.',
       });
       return { findings };
     }
@@ -134,14 +142,17 @@ export class FieldLevelSecurityCheck implements SecurityCheck {
       permRecords = result.records.map((r) => ({ Field: r.Field, cnt: r.cnt ?? 0 }));
     } catch {
       findings.push({
-        id: 'field-level-security-ok',
+        id: 'field-level-security-inaccessible',
         category: this.category,
-        riskLevel: 'LOW',
-        passed: true,
-        title: 'Sensitive custom fields appear appropriately restricted',
-        detail: 'No sensitive custom fields with excessive permission set access were found.',
+        riskLevel: 'INFO',
+        inconclusive: true,
+        title: `Field-level security could not be evaluated for ${fieldApiNames.length} sensitive field(s)`,
+        detail:
+          'The FieldPermissions query was not accessible, so how widely these sensitive fields are readable could not be determined. ' +
+          'The fields themselves were found; only their exposure is unknown.',
         remediation:
-          'Continue to apply restrictive field-level security to any new sensitive fields.',
+          'Grant the audit user access to FieldPermissions and re-run. Until then, review field-level security manually for the fields listed.',
+        affectedItems: fieldApiNames.map((f) => ({ label: f })),
       });
       return { findings };
     }
@@ -196,9 +207,14 @@ export class FieldLevelSecurityCheck implements SecurityCheck {
         id: 'field-level-security-ok',
         category: this.category,
         riskLevel: 'LOW',
-        passed: true,
-        title: 'Sensitive custom fields appear appropriately restricted',
-        detail: 'No sensitive custom fields with excessive permission set access were found.',
+        // A pass only where the analysis actually covered everything found.
+        ...(unresolvedCount > 0 ? { inconclusive: true } : { passed: true }),
+        title: unresolvedCount > 0
+          ? `Sensitive custom fields appear restricted, but ${unresolvedCount} could not be evaluated`
+          : 'Sensitive custom fields appear appropriately restricted',
+        detail: unresolvedCount > 0
+          ? `No excessive permission-set access was found among the ${fieldApiNames.length} field(s) that could be evaluated, but ${unresolvedCount} sensitive field(s) could not be resolved to an object and were not checked.`
+          : 'No sensitive custom fields with excessive permission set access were found.',
         remediation:
           'Continue to apply restrictive field-level security to any new sensitive fields.',
       });

--- a/src/checks/impl/IpRestrictionsCheck.ts
+++ b/src/checks/impl/IpRestrictionsCheck.ts
@@ -62,7 +62,11 @@ export class IpRestrictionsCheck implements SecurityCheck {
     );
 
     // 2. Profile IP ranges — try SOQL first, fallback to Tooling
+    // "Unreadable" and "none configured" are different facts and must not be conflated: an
+    // empty result would make every admin look unrestricted, asserting a finding the data
+    // cannot support.
     let ipRanges: IpRangeRecord[] = [];
+    let rangesUnavailable = false;
     try {
       ipRanges = await ctx.soql.queryAll<IpRangeRecord>(
         'SELECT ProfileId, StartAddress, EndAddress FROM ProfileLoginIpRange'
@@ -73,8 +77,7 @@ export class IpRestrictionsCheck implements SecurityCheck {
           'SELECT ProfileId, StartAddress, EndAddress FROM ProfileLoginIpRange'
         );
       } catch {
-        // No IP ranges configured or not accessible — treat as empty
-        ipRanges = [];
+        rangesUnavailable = true;
       }
     }
 
@@ -86,6 +89,7 @@ export class IpRestrictionsCheck implements SecurityCheck {
     //   'WhiteList'→ enforce the org-level IP whitelist (secure)
     const ipBypassingApps: Array<{ name: string; id: string }> = [];
     const ipRelaxingApps: Array<{ name: string; id: string }> = [];
+    let appsUnavailable = false;
     try {
       const connectedApps = await ctx.tooling.query<ConnectedAppRecord>(
         'SELECT Id, Name, Metadata FROM ConnectedApplication'
@@ -99,7 +103,8 @@ export class IpRestrictionsCheck implements SecurityCheck {
         }
       }
     } catch {
-      // Metadata field not accessible — skip connected app IP check
+      // Recorded so the result cannot be read as "no relaxed apps".
+      appsUnavailable = true;
     }
 
     // Determine which profile IDs have at least one IP range
@@ -110,7 +115,26 @@ export class IpRestrictionsCheck implements SecurityCheck {
       (u) => !profilesWithRanges.has(u.ProfileId)
     );
 
-    if (unrestrictedAdmins.length > 0) {
+    if (rangesUnavailable && adminUsers.length > 0) {
+      findings.push({
+        id: 'ip-restrictions-ranges-unavailable',
+        category: this.category,
+        riskLevel: 'INFO',
+        inconclusive: true,
+        title: `Login IP ranges could not be read; ${adminUsers.length} admin profile(s) were not evaluated`,
+        detail:
+          'ProfileLoginIpRange was not queryable via SOQL or the Tooling API, so whether these admin profiles restrict login by IP is unknown. It is not reported as unrestricted, because the data does not support that conclusion.',
+        remediation:
+          'Grant the audit user access to ProfileLoginIpRange and re-run, or review Login IP Ranges manually in Setup → Profiles.',
+        affectedItems: adminUsers.map((u) => ({
+          label: u.Username,
+          url: `${baseUrl}/${u.Id}`,
+          note: `Profile: ${u.Profile.Name}: IP range configuration unknown`,
+        })),
+      });
+    }
+
+    if (!rangesUnavailable && unrestrictedAdmins.length > 0) {
       findings.push({
         id: 'admin-no-ip-restrictions',
         category: this.category,
@@ -125,6 +149,20 @@ export class IpRestrictionsCheck implements SecurityCheck {
           'Administrator accounts without IP login restrictions can be accessed from any network, increasing exposure to credential-stuffing attacks.',
         remediation:
           'Add IP login ranges to all admin profiles in Setup → Profiles → Login IP Ranges, or enable MFA as a compensating control.',
+      });
+    }
+
+    if (appsUnavailable) {
+      findings.push({
+        id: 'ip-restrictions-apps-unavailable',
+        category: this.category,
+        riskLevel: 'INFO',
+        inconclusive: true,
+        title: 'Connected app IP relaxation settings could not be read',
+        detail:
+          'The ConnectedApplication Metadata field was not accessible, so whether any connected app bypasses or relaxes login IP enforcement is unknown.',
+        remediation:
+          'Grant the audit user access to the Tooling API ConnectedApplication Metadata field and re-run, or review IP Relaxation per app in Setup → Connected Apps.',
       });
     }
 
@@ -211,6 +249,8 @@ export class IpRestrictionsCheck implements SecurityCheck {
     }
 
     if (
+      !rangesUnavailable &&
+      !appsUnavailable &&
       unrestrictedAdmins.length === 0 &&
       ipBypassingApps.length === 0 &&
       ipRelaxingApps.length === 0 &&

--- a/src/checks/impl/PublicGroupSharingCheck.ts
+++ b/src/checks/impl/PublicGroupSharingCheck.ts
@@ -57,6 +57,10 @@ export class PublicGroupSharingCheck implements SecurityCheck {
     const groupNameMap = new Map(groups.map((g) => [g.Id, g.Name]));
 
     const exposures: Exposure[] = [];
+    // Which share tables could not be read. An object may be absent from the org edition or
+    // simply not permitted; either way the check did not see it, and the conclusion has to say
+    // so rather than count silence as evidence of no sharing.
+    const unreadable: string[] = [];
     for (const shareTable of SHARE_TABLES) {
       try {
         const result = await ctx.soql.query<SharingCountRecord>(
@@ -76,7 +80,7 @@ export class PublicGroupSharingCheck implements SecurityCheck {
           }
         }
       } catch {
-        // Object may not exist or not be accessible — skip silently
+        unreadable.push(shareTable);
       }
     }
 
@@ -99,14 +103,30 @@ export class PublicGroupSharingCheck implements SecurityCheck {
         remediation:
           'Replace "All Internal Users" sharing rules with more targeted public groups or role-based sharing.',
       });
+    } else if (unreadable.length === SHARE_TABLES.length) {
+      // Nothing was readable, so "no exposure found" would be an assertion about data never seen.
+      findings.push({
+        id: 'public-group-sharing-inconclusive',
+        category: this.category,
+        riskLevel: 'INFO',
+        inconclusive: true,
+        title: 'Sharing to All Internal Users could not be evaluated',
+        detail:
+          `None of the share tables (${SHARE_TABLES.join(', ')}) could be queried, so whether sharing rules target the "All Internal Users" group is unknown. ${groups.length} such group(s) exist in this org.`,
+        remediation:
+          'Grant the audit user read access to the share tables and re-run, or review sharing rules manually in Setup → Sharing Settings.',
+      });
     } else {
+      const checked = SHARE_TABLES.filter((s) => !unreadable.includes(s));
       findings.push({
         id: 'public-group-sharing-none',
         category: this.category,
         riskLevel: 'LOW',
         passed: true,
         title: 'No records shared to All Internal Users groups via sharing rules',
-        detail: 'No sharing rules were found targeting the "All Internal Users" group on key objects.',
+        detail: unreadable.length > 0
+          ? `No sharing rules targeting the "All Internal Users" group were found on ${checked.join(', ')}. ${unreadable.join(', ')} could not be queried and were not checked.`
+          : 'No sharing rules were found targeting the "All Internal Users" group on key objects.',
         remediation:
           'Continue to avoid broad sharing rules. Periodically review sharing configuration as the org grows.',
       });

--- a/test/unit/checks/impl/CertificateExpiryCheck.test.ts
+++ b/test/unit/checks/impl/CertificateExpiryCheck.test.ts
@@ -1,0 +1,129 @@
+import { jest } from '@jest/globals';
+import { CertificateExpiryCheck } from '../../../../src/checks/impl/CertificateExpiryCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+
+function makeCtx(certs: unknown[] | Error): AuditContext {
+  return {
+    soql: {} as any,
+    tooling: {
+      query: (jest.fn() as any).mockImplementation(() =>
+        certs instanceof Error ? Promise.reject(certs) : Promise.resolve(certs),
+      ),
+      getRecord: jest.fn(),
+    } as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: {} as any,
+  } as any;
+}
+
+const DAY = 86_400_000;
+
+/**
+ * A certificate expiring `days` from now. Dates are computed relative to the moment the test
+ * runs, because the check reads Date.now() — a fixed date would rot.
+ */
+const cert = (label: string, days: number | null) => ({
+  Id: `0PE${label}`,
+  MasterLabel: label,
+  DeveloperName: label.replace(/\W/g, '_'),
+  ExpirationDate: days === null ? null : new Date(Date.now() + days * DAY).toISOString(),
+});
+
+describe('CertificateExpiryCheck', () => {
+  const check = new CertificateExpiryCheck();
+
+  it('is inconclusive when the Certificate object is unreadable', async () => {
+    const r = await check.run(makeCtx(new Error('INSUFFICIENT_ACCESS')));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('certificate-inaccessible');
+    expect(r.findings[0].inconclusive).toBe(true);
+    expect(r.findings[0].passed).toBeUndefined();
+  });
+
+  it('reports an INFO finding, not a pass, when the org has no certificates', async () => {
+    const r = await check.run(makeCtx([]));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('certificate-none');
+    expect(r.findings[0].riskLevel).toBe('INFO');
+    // No certificates is an absence of evidence, not a healthy result.
+    expect(r.findings[0].passed).toBeUndefined();
+  });
+
+  it('passes when every certificate has more than 180 days left', async () => {
+    const r = await check.run(makeCtx([cert('Prod', 200), cert('Backup', 365)]));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('certificate-ok');
+    expect(r.findings[0].passed).toBe(true);
+    expect(r.findings[0].title).toContain('2 certificate(s)');
+  });
+
+  // The three thresholds, tested either side of each boundary.
+  it.each([
+    [10, 'certificate-expiring-critical', 'CRITICAL'],
+    [30, 'certificate-expiring-critical', 'CRITICAL'],
+    [45, 'certificate-expiring-soon', 'HIGH'],
+    [90, 'certificate-expiring-soon', 'HIGH'],
+    [120, 'certificate-expiring-medium', 'MEDIUM'],
+    [179, 'certificate-expiring-medium', 'MEDIUM'],
+  ])('a certificate %i days out is %s (%s)', async (days, id, severity) => {
+    const r = await check.run(makeCtx([cert('C', days)]));
+    const f = r.findings.find((x) => x.id === id);
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe(severity);
+    // It must land in exactly one bucket.
+    expect(r.findings).toHaveLength(1);
+  });
+
+  it('treats an already-expired certificate as CRITICAL', async () => {
+    const r = await check.run(makeCtx([cert('Lapsed', -30)]));
+    const f = r.findings.find((x) => x.id === 'certificate-expiring-critical');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('CRITICAL');
+    // The note carries the negative day count, so an expired cert reads as expired.
+    expect(f!.affectedItems?.[0].note).toMatch(/-?\d+ day\(s\)/);
+  });
+
+  it('separates certificates into all three buckets in one run', async () => {
+    const r = await check.run(makeCtx([
+      cert('Urgent', 5), cert('Soon', 60), cert('Later', 150), cert('Fine', 400),
+    ]));
+    const ids = r.findings.map((f) => f.id);
+    expect(ids).toEqual(expect.arrayContaining([
+      'certificate-expiring-critical', 'certificate-expiring-soon', 'certificate-expiring-medium',
+    ]));
+    // The healthy one does not produce a pass finding alongside real problems.
+    expect(ids).not.toContain('certificate-ok');
+    for (const id of ids) {
+      expect(r.findings.find((f) => f.id === id)!.affectedItems).toHaveLength(1);
+    }
+  });
+
+  it('includes the expiry date in the note so it can be acted on without the org', async () => {
+    const r = await check.run(makeCtx([cert('Prod', 10)]));
+    const note = r.findings[0].affectedItems?.[0].note!;
+    expect(note).toMatch(/expires \d{4}-\d{2}-\d{2}/);
+  });
+
+  /**
+   * A certificate with no ExpirationDate is skipped by the bucketing loop. If it is the only
+   * certificate, the check reports `certificate-ok` — "All 1 certificate(s) are healthy" — for a
+   * certificate whose expiry is unknown. Pinned as current behaviour; worth revisiting, since
+   * "we could not tell" and "it is fine" are different answers.
+   */
+  it('currently reports a null expiry date as healthy', async () => {
+    const r = await check.run(makeCtx([cert('Unknown', null)]));
+    expect(r.findings[0].id).toBe('certificate-ok');
+    expect(r.findings[0].passed).toBe(true);
+  });
+
+  it('ignores a null-expiry certificate without hiding a real one', async () => {
+    const r = await check.run(makeCtx([cert('Unknown', null), cert('Urgent', 5)]));
+    expect(r.findings.some((f) => f.id === 'certificate-expiring-critical')).toBe(true);
+    expect(r.findings.find((f) => f.id === 'certificate-expiring-critical')!.affectedItems)
+      .toHaveLength(1);
+  });
+});

--- a/test/unit/checks/impl/FieldLevelSecurityCheck.test.ts
+++ b/test/unit/checks/impl/FieldLevelSecurityCheck.test.ts
@@ -1,0 +1,173 @@
+import { jest } from '@jest/globals';
+import { FieldLevelSecurityCheck } from '../../../../src/checks/impl/FieldLevelSecurityCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+
+type ToolingQ = (soql: string) => Promise<unknown[]>;
+type SoqlQ = (soql: string) => Promise<{ records: unknown[] }>;
+
+function makeCtx(opts: { tooling?: ToolingQ; query?: SoqlQ } = {}): AuditContext {
+  return {
+    soql: {
+      queryAll: jest.fn(),
+      query: (jest.fn() as any).mockImplementation((s: string) =>
+        opts.query ? opts.query(s) : Promise.resolve({ records: [] }),
+      ),
+    } as any,
+    tooling: {
+      query: (jest.fn() as any).mockImplementation((s: string) =>
+        opts.tooling ? opts.tooling(s) : Promise.resolve([]),
+      ),
+      getRecord: jest.fn(),
+    } as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: {} as any,
+  } as any;
+}
+
+const field = (DeveloperName: string, TableEnumOrId: string, Id = '00N1') =>
+  ({ Id, DeveloperName, TableEnumOrId });
+
+/** Route tooling queries: CustomField vs EntityDefinition. */
+const tooling = (o: { fields?: unknown[]; entities?: unknown[]; entityError?: boolean }): ToolingQ => (s) => {
+  if (/FROM CustomField/i.test(s)) return Promise.resolve(o.fields ?? []);
+  if (/FROM EntityDefinition/i.test(s)) {
+    return o.entityError ? Promise.reject(new Error('no access')) : Promise.resolve(o.entities ?? []);
+  }
+  return Promise.resolve([]);
+};
+
+const perms = (rows: Array<{ Field: string; cnt: number }>): SoqlQ => () => Promise.resolve({ records: rows });
+
+describe('FieldLevelSecurityCheck', () => {
+  const check = new FieldLevelSecurityCheck();
+
+  it('passes when no sensitive-looking custom fields exist', async () => {
+    const r = await check.run(makeCtx({ tooling: tooling({ fields: [] }) }));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('field-level-security-ok');
+    expect(r.findings[0].passed).toBe(true);
+  });
+
+  it('searches for the documented sensitive name patterns', async () => {
+    const seen: string[] = [];
+    await check.run(makeCtx({ tooling: (s) => { seen.push(s); return Promise.resolve([]); } }));
+    const q = seen.find((s) => /FROM CustomField/i.test(s))!;
+    for (const pattern of ['SSN', 'CreditCard', 'BankAccount', 'DateOfBirth', 'MedicalRecord', 'Diagnosis']) {
+      expect(q).toContain(pattern);
+    }
+  });
+
+  it('uses TableEnumOrId directly for a standard object', async () => {
+    const seen: string[] = [];
+    const r = await check.run(makeCtx({
+      tooling: tooling({ fields: [field('SSN', 'Account')] }),
+      query: (s) => { seen.push(s); return Promise.resolve({ records: [] }); },
+    }));
+    // No EntityDefinition lookup is needed, and the field name is built directly.
+    expect(seen[0]).toContain('Account.SSN__c');
+    expect(r.findings[0].id).toBe('field-level-security-ok');
+  });
+
+  it('resolves a custom object id through EntityDefinition', async () => {
+    const seen: string[] = [];
+    await check.run(makeCtx({
+      tooling: tooling({
+        fields: [field('SSN', '01I5000000AbCdEfGh')],
+        entities: [{ Id: '01I5000000AbCdEfGh', QualifiedApiName: 'Patient__c' }],
+      }),
+      query: (s) => { seen.push(s); return Promise.resolve({ records: [] }); },
+    }));
+    expect(seen[0]).toContain('Patient__c.SSN__c');
+  });
+
+  it('flags fields readable by more than 15 permission sets as HIGH', async () => {
+    const r = await check.run(makeCtx({
+      tooling: tooling({ fields: [field('SSN', 'Account')] }),
+      query: perms([{ Field: 'Account.SSN__c', cnt: 16 }]),
+    }));
+    const f = r.findings.find((x) => x.id === 'field-level-security-high');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('HIGH');
+    expect(f!.affectedItems?.[0].note).toContain('16');
+  });
+
+  it('flags 10-15 permission sets as MEDIUM and leaves 10 or fewer alone', async () => {
+    const medium = await check.run(makeCtx({
+      tooling: tooling({ fields: [field('SSN', 'Account')] }),
+      query: perms([{ Field: 'Account.SSN__c', cnt: 12 }]),
+    }));
+    expect(medium.findings.find((x) => x.id === 'field-level-security-medium')!.riskLevel).toBe('MEDIUM');
+
+    const fine = await check.run(makeCtx({
+      tooling: tooling({ fields: [field('SSN', 'Account')] }),
+      query: perms([{ Field: 'Account.SSN__c', cnt: 10 }]),
+    }));
+    expect(fine.findings[0].id).toBe('field-level-security-ok');
+  });
+
+  it('reports high and medium exposure separately in one run', async () => {
+    const r = await check.run(makeCtx({
+      tooling: tooling({ fields: [field('SSN', 'Account'), field('DOB', 'Contact')] }),
+      query: perms([
+        { Field: 'Account.SSN__c', cnt: 20 },
+        { Field: 'Contact.DOB__c', cnt: 11 },
+      ]),
+    }));
+    const ids = r.findings.map((f) => f.id);
+    expect(ids).toContain('field-level-security-high');
+    expect(ids).toContain('field-level-security-medium');
+    expect(ids).not.toContain('field-level-security-ok');
+  });
+
+  it('reports an INFO finding when the CustomField query fails', async () => {
+    const r = await check.run(makeCtx({ tooling: () => Promise.reject(new Error('INSUFFICIENT_ACCESS')) }));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('field-level-security-query-error');
+    expect(r.findings[0].passed).toBeUndefined();
+  });
+
+  /**
+   * The three cases below pin CURRENT behaviour, which is wrong and should be changed.
+   *
+   * When this check cannot complete its analysis — FieldPermissions unreadable, or a custom
+   * object that EntityDefinition would not resolve — it emits `field-level-security-ok` with
+   * `passed: true` and the text "Sensitive custom fields appear appropriately restricted".
+   * That reports a clean result for an analysis that never ran, which is the one outcome a
+   * security tool must not produce. CLAUDE.md's own rule is that permission errors surface as
+   * `inconclusive: true`, and SharingModelCheck does exactly that.
+   *
+   * These tests are deliberately named for the defect so it cannot be mistaken for intent.
+   * When it is fixed, they should be inverted to assert `inconclusive: true`.
+   */
+  describe('known defect: unanalysable states are reported as a pass', () => {
+    it('DEFECT: an unreadable FieldPermissions query yields passed:true', async () => {
+      const r = await check.run(makeCtx({
+        tooling: tooling({ fields: [field('SSN', 'Account')] }),
+        query: () => Promise.reject(new Error('INSUFFICIENT_ACCESS')),
+      }));
+      expect(r.findings[0].id).toBe('field-level-security-ok');
+      expect(r.findings[0].passed).toBe(true);
+      expect(r.findings[0].inconclusive).toBeUndefined();
+    });
+
+    it('DEFECT: a failed EntityDefinition lookup yields passed:true', async () => {
+      const r = await check.run(makeCtx({
+        tooling: tooling({ fields: [field('SSN', '01I5000000AbCdEfGh')], entityError: true }),
+      }));
+      expect(r.findings[0].id).toBe('field-level-security-ok');
+      expect(r.findings[0].passed).toBe(true);
+    });
+
+    it('DEFECT: unresolvable object ids yield passed:true rather than inconclusive', async () => {
+      const r = await check.run(makeCtx({
+        tooling: tooling({ fields: [field('SSN', '01I5000000AbCdEfGh')], entities: [] }),
+      }));
+      expect(r.findings[0].id).toBe('field-level-security-ok');
+      expect(r.findings[0].passed).toBe(true);
+    });
+  });
+});

--- a/test/unit/checks/impl/FieldLevelSecurityCheck.test.ts
+++ b/test/unit/checks/impl/FieldLevelSecurityCheck.test.ts
@@ -131,43 +131,64 @@ describe('FieldLevelSecurityCheck', () => {
   });
 
   /**
-   * The three cases below pin CURRENT behaviour, which is wrong and should be changed.
-   *
-   * When this check cannot complete its analysis — FieldPermissions unreadable, or a custom
-   * object that EntityDefinition would not resolve — it emits `field-level-security-ok` with
-   * `passed: true` and the text "Sensitive custom fields appear appropriately restricted".
-   * That reports a clean result for an analysis that never ran, which is the one outcome a
-   * security tool must not produce. CLAUDE.md's own rule is that permission errors surface as
-   * `inconclusive: true`, and SharingModelCheck does exactly that.
-   *
-   * These tests are deliberately named for the defect so it cannot be mistaken for intent.
-   * When it is fixed, they should be inverted to assert `inconclusive: true`.
+   * These three states are all "we could not complete the analysis". They must never render as
+   * a pass: a report that says "Sensitive custom fields appear appropriately restricted" when
+   * FieldPermissions was unreadable is a false assurance about SSNs and medical records.
    */
-  describe('known defect: unanalysable states are reported as a pass', () => {
-    it('DEFECT: an unreadable FieldPermissions query yields passed:true', async () => {
+  describe('unanalysable states report what is unknown, never a pass', () => {
+    it('is inconclusive when FieldPermissions cannot be read', async () => {
       const r = await check.run(makeCtx({
         tooling: tooling({ fields: [field('SSN', 'Account')] }),
         query: () => Promise.reject(new Error('INSUFFICIENT_ACCESS')),
       }));
-      expect(r.findings[0].id).toBe('field-level-security-ok');
-      expect(r.findings[0].passed).toBe(true);
-      expect(r.findings[0].inconclusive).toBeUndefined();
+      expect(r.findings[0].id).toBe('field-level-security-inaccessible');
+      expect(r.findings[0].inconclusive).toBe(true);
+      expect(r.findings[0].passed).toBeUndefined();
+      // The fields it did find are still named, so the reader can check them by hand.
+      expect(r.findings[0].affectedItems?.[0].label).toBe('Account.SSN__c');
     });
 
-    it('DEFECT: a failed EntityDefinition lookup yields passed:true', async () => {
+    it('is inconclusive when the EntityDefinition lookup fails, and says so', async () => {
       const r = await check.run(makeCtx({
         tooling: tooling({ fields: [field('SSN', '01I5000000AbCdEfGh')], entityError: true }),
       }));
-      expect(r.findings[0].id).toBe('field-level-security-ok');
-      expect(r.findings[0].passed).toBe(true);
+      expect(r.findings[0].id).toBe('field-level-security-unresolved');
+      expect(r.findings[0].inconclusive).toBe(true);
+      expect(r.findings[0].detail).toContain('EntityDefinition');
     });
 
-    it('DEFECT: unresolvable object ids yield passed:true rather than inconclusive', async () => {
+    it('is inconclusive when object ids resolve to nothing', async () => {
       const r = await check.run(makeCtx({
         tooling: tooling({ fields: [field('SSN', '01I5000000AbCdEfGh')], entities: [] }),
       }));
-      expect(r.findings[0].id).toBe('field-level-security-ok');
-      expect(r.findings[0].passed).toBe(true);
+      expect(r.findings[0].id).toBe('field-level-security-unresolved');
+      expect(r.findings[0].inconclusive).toBe(true);
+      expect(r.findings[0].passed).toBeUndefined();
+    });
+
+    it('downgrades a clean result to inconclusive when some fields were skipped', async () => {
+      // One resolvable field with acceptable exposure, one that cannot be resolved.
+      const r = await check.run(makeCtx({
+        tooling: tooling({
+          fields: [field('SSN', 'Account'), field('DOB', '01I5000000AbCdEfGh')],
+          entities: [],
+        }),
+        query: perms([{ Field: 'Account.SSN__c', cnt: 2 }]),
+      }));
+      const f = r.findings.find((x) => x.id === 'field-level-security-ok')!;
+      expect(f.inconclusive).toBe(true);
+      expect(f.passed).toBeUndefined();
+      expect(f.title).toContain('1 could not be evaluated');
+    });
+
+    it('still passes cleanly when everything was evaluated', async () => {
+      const r = await check.run(makeCtx({
+        tooling: tooling({ fields: [field('SSN', 'Account')] }),
+        query: perms([{ Field: 'Account.SSN__c', cnt: 2 }]),
+      }));
+      const f = r.findings.find((x) => x.id === 'field-level-security-ok')!;
+      expect(f.passed).toBe(true);
+      expect(f.inconclusive).toBeUndefined();
     });
   });
 });

--- a/test/unit/checks/impl/GuestUserAccessCheck.test.ts
+++ b/test/unit/checks/impl/GuestUserAccessCheck.test.ts
@@ -1,0 +1,196 @@
+import { jest } from '@jest/globals';
+import { GuestUserAccessCheck } from '../../../../src/checks/impl/GuestUserAccessCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+
+type QueryAll = (soql: string) => Promise<unknown[]>;
+type Query = (soql: string) => Promise<{ records: unknown[] }>;
+
+function makeCtx(opts: {
+  queryAll?: QueryAll;
+  query?: Query;
+  healthCloudInstalled?: boolean;
+} = {}): AuditContext {
+  return {
+    soql: {
+      queryAll: (jest.fn() as any).mockImplementation((s: string) =>
+        opts.queryAll ? opts.queryAll(s) : Promise.resolve([]),
+      ),
+      query: (jest.fn() as any).mockImplementation((s: string) =>
+        opts.query ? opts.query(s) : Promise.resolve({ records: [] }),
+      ),
+    } as any,
+    tooling: {} as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: { healthCloudInstalled: opts.healthCloudInstalled } as any,
+  } as any;
+}
+
+const guest = (id = '005G', profileId = '00eG', username = 'guest@site.com') => ({
+  Id: id, ProfileId: profileId, Username: username,
+});
+
+const perm = (over: Record<string, unknown> = {}) => ({
+  ParentId: '00eG', SobjectType: 'Account',
+  PermissionsCreate: false, PermissionsEdit: false,
+  PermissionsDelete: false, PermissionsRead: false,
+  ...over,
+});
+
+/** Route a query by the object it hits, so fixtures do not depend on call order. */
+const router = (opts: { users?: unknown[]; perms?: unknown[] }): QueryAll => (soql) => {
+  if (/FROM User\b/i.test(soql)) return Promise.resolve(opts.users ?? []);
+  if (/FROM ObjectPermissions/i.test(soql)) return Promise.resolve(opts.perms ?? []);
+  return Promise.resolve([]);
+};
+
+describe('GuestUserAccessCheck', () => {
+  const check = new GuestUserAccessCheck();
+
+  it('declares its identity and cache contract', () => {
+    expect(check.id).toBe('guest-user-access');
+    expect(check.dependsOnCache).toEqual(expect.arrayContaining(['healthCloudInstalled']));
+  });
+
+  it('passes when there are no active guest users', async () => {
+    const r = await check.run(makeCtx({ queryAll: router({ users: [] }) }));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('guest-user-none');
+    expect(r.findings[0].passed).toBe(true);
+  });
+
+  it('only queries for ACTIVE guest users', async () => {
+    const seen: string[] = [];
+    await check.run(makeCtx({
+      queryAll: (s) => { seen.push(s); return Promise.resolve([]); },
+    }));
+    const userQuery = seen.find((s) => /FROM User\b/i.test(s));
+    expect(userQuery).toMatch(/UserType\s*=\s*'Guest'/i);
+    expect(userQuery).toMatch(/IsActive\s*=\s*true/i);
+  });
+
+  // The CRITICAL path: an unauthenticated identity that can change data.
+  it.each([
+    ['PermissionsCreate', { PermissionsCreate: true }],
+    ['PermissionsEdit', { PermissionsEdit: true }],
+    ['PermissionsDelete', { PermissionsDelete: true }],
+  ])('flags %s on a guest profile as CRITICAL write access', async (_label, over) => {
+    const r = await check.run(makeCtx({
+      queryAll: router({ users: [guest()], perms: [perm(over)] }),
+    }));
+    const f = r.findings.find((x) => x.id === 'guest-user-write-access');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('CRITICAL');
+    expect(f!.affectedItems?.[0].label).toContain('Account');
+  });
+
+  it('flags read-only guest access as HIGH, per SBS-CPORTAL-002', async () => {
+    const r = await check.run(makeCtx({
+      queryAll: router({ users: [guest()], perms: [perm({ PermissionsRead: true })] }),
+    }));
+    const f = r.findings.find((x) => x.id === 'guest-user-read-access');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('HIGH');
+    // Read access alone must not be reported as write access.
+    expect(r.findings.some((x) => x.id === 'guest-user-write-access')).toBe(false);
+  });
+
+  it('reports write access rather than read when a profile has both', async () => {
+    const r = await check.run(makeCtx({
+      queryAll: router({
+        users: [guest()],
+        perms: [perm({ PermissionsRead: true, PermissionsEdit: true })],
+      }),
+    }));
+    expect(r.findings.some((x) => x.id === 'guest-user-write-access')).toBe(true);
+    expect(r.findings.some((x) => x.id === 'guest-user-read-access')).toBe(false);
+  });
+
+  it('attributes a profile permission to every guest user on that profile', async () => {
+    const r = await check.run(makeCtx({
+      queryAll: router({
+        users: [guest('005A', '00eG', 'a@x.com'), guest('005B', '00eG', 'b@x.com')],
+        perms: [perm({ PermissionsEdit: true })],
+      }),
+    }));
+    const f = r.findings.find((x) => x.id === 'guest-user-write-access')!;
+    expect(f.affectedItems).toHaveLength(2);
+    expect(JSON.stringify(f.affectedItems)).toContain('a@x.com');
+    expect(JSON.stringify(f.affectedItems)).toContain('b@x.com');
+  });
+
+  it('flags sharing rules that target a guest user', async () => {
+    const r = await check.run(makeCtx({
+      queryAll: router({ users: [guest()] }),
+      query: (s) => Promise.resolve(
+        /FROM AccountShare/i.test(s) ? { records: [{ UserOrGroupId: '005G', cnt: 3 }] } : { records: [] },
+      ),
+    }));
+    const f = r.findings.find((x) => x.id === 'guest-user-sharing-exposure');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('HIGH');
+    expect(f!.title).toContain('3');
+  });
+
+  it('only counts sharing rows whose RowCause is SharingRule', async () => {
+    const seen: string[] = [];
+    await check.run(makeCtx({
+      queryAll: router({ users: [guest()] }),
+      query: (s) => { seen.push(s); return Promise.resolve({ records: [] }); },
+    }));
+    expect(seen.length).toBeGreaterThan(0);
+    for (const s of seen) expect(s).toMatch(/RowCause\s*=\s*'SharingRule'/i);
+  });
+
+  it('falls back to the baseline finding when guests exist but hold no access', async () => {
+    const r = await check.run(makeCtx({ queryAll: router({ users: [guest()] }) }));
+    const f = r.findings.find((x) => x.id === 'guest-user-baseline');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('MEDIUM');
+    // The baseline is mutually exclusive with the three exposure findings.
+    expect(r.findings).toHaveLength(1);
+  });
+
+  it('includes Health Cloud objects only when the cache says it is installed', async () => {
+    const withHc: string[] = [];
+    await check.run(makeCtx({
+      healthCloudInstalled: true,
+      queryAll: (s) => { withHc.push(s); return Promise.resolve(/FROM User\b/i.test(s) ? [guest()] : []); },
+    }));
+    const withoutHc: string[] = [];
+    await check.run(makeCtx({
+      healthCloudInstalled: false,
+      queryAll: (s) => { withoutHc.push(s); return Promise.resolve(/FROM User\b/i.test(s) ? [guest()] : []); },
+    }));
+    const hcQuery = withHc.find((s) => /FROM ObjectPermissions/i.test(s))!;
+    const plainQuery = withoutHc.find((s) => /FROM ObjectPermissions/i.test(s))!;
+    expect(hcQuery).toContain('CarePlan__c');
+    expect(plainQuery).not.toContain('CarePlan__c');
+    // Standard objects are always in scope.
+    expect(plainQuery).toContain('Account');
+  });
+
+  it('degrades to the baseline when ObjectPermissions is not readable', async () => {
+    const r = await check.run(makeCtx({
+      queryAll: (s) => {
+        if (/FROM User\b/i.test(s)) return Promise.resolve([guest()]);
+        if (/FROM ObjectPermissions/i.test(s)) return Promise.reject(new Error('INSUFFICIENT_ACCESS'));
+        return Promise.resolve([]);
+      },
+    }));
+    // A permission query it cannot run must not be reported as "no exposure found" silently
+    // failing — it still reports the guest users themselves.
+    expect(r.findings.some((x) => x.id === 'guest-user-baseline')).toBe(true);
+  });
+
+  it('survives a share table that is not queryable', async () => {
+    const r = await check.run(makeCtx({
+      queryAll: router({ users: [guest()] }),
+      query: () => Promise.reject(new Error('no such object')),
+    }));
+    expect(r.findings.some((x) => x.id === 'guest-user-baseline')).toBe(true);
+  });
+});

--- a/test/unit/checks/impl/HardcodedCredentialsCheck.test.ts
+++ b/test/unit/checks/impl/HardcodedCredentialsCheck.test.ts
@@ -1,0 +1,202 @@
+import { jest } from '@jest/globals';
+import { HardcodedCredentialsCheck } from '../../../../src/checks/impl/HardcodedCredentialsCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+
+/** ApexRepository.listClasses issues one tooling query against ApexClass. */
+const apexClass = (Name: string, Body: string, NamespacePrefix: string | null = null) =>
+  ({ Name, NamespacePrefix, Body, SymbolTable: null });
+
+function makeCtx(classes: unknown[], cache: Record<string, unknown> = {}): AuditContext {
+  return {
+    soql: {} as any,
+    tooling: {
+      query: (jest.fn() as any).mockImplementation(() => Promise.resolve(classes)),
+      getRecord: jest.fn(),
+    } as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: { ...cache } as any,
+  } as any;
+}
+
+// Long enough to clear the minimum-length guards that keep test stubs out of the results.
+const BEARER = 'Bearer abcdefghijklmnopqrstuvwxyz0123456789';
+const BASIC = 'Basic YWRtaW46c3VwZXJzZWNyZXRwYXNzd29yZA==';
+
+describe('HardcodedCredentialsCheck', () => {
+  const check = new HardcodedCredentialsCheck();
+
+  it('declares its cache contract in both directions', () => {
+    expect(check.dependsOnCache).toEqual(
+      expect.arrayContaining(['namedCredentialEndpoints', 'remoteSiteUrls']),
+    );
+    expect(check.populatesCache).toEqual(expect.arrayContaining(['apexBodies']));
+  });
+
+  it('passes when nothing suspicious is present', async () => {
+    const ctx = makeCtx([apexClass('Clean', 'public class Clean { }')]);
+    const r = await check.run(ctx);
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('no-hardcoded-credentials');
+    expect(r.findings[0].passed).toBe(true);
+    expect(r.findings[0].detail).toContain('1 custom Apex classes');
+  });
+
+  it.each([
+    ['a Bearer token', `String h = '${BEARER}';`],
+    ['Basic auth', `String h = '${BASIC}';`],
+    ['an Authorization header literal', `String h = '{"Authorization": "Bearer xyz"}';`],
+    ['a password assignment', `String password = 'hunter2hunter2';`],
+    ['a client secret assignment', `String client_secret = 'abcdefghijkl';`],
+    ['an api key assignment', `String apiKey = 'k9sdf7sdf8sdf';`],
+  ])('detects %s', async (_label, body) => {
+    const ctx = makeCtx([apexClass('Leaky', `public class Leaky { ${body} }`)]);
+    const r = await check.run(ctx);
+    const f = r.findings.find((x) => x.id === 'hardcoded-credentials-found');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('HIGH');
+    expect(f!.affectedItems?.[0].label).toBe('Leaky');
+  });
+
+  // Apex's usual idiom is `req.setHeader('Authorization', 'Bearer ' + token)`. The comma stops
+  // the Authorization pattern matching, which is right: a token held in a variable is not a
+  // hardcoded credential. Detection there depends on the Bearer/Basic patterns instead, and
+  // only when the literal is long enough to be a real secret.
+  it('does not flag an Authorization header built from a variable', async () => {
+    const ctx = makeCtx([apexClass('Ok', `req.setHeader('Authorization', 'Bearer ' + token);`)]);
+    const r = await check.run(ctx);
+    expect(r.findings[0].id).toBe('no-hardcoded-credentials');
+  });
+
+  it('flags the same idiom when the token is inlined', async () => {
+    const ctx = makeCtx([apexClass('Bad', `req.setHeader('Authorization', '${'Bearer abcdefghijklmnopqrstuvwxyz0123456789'}');`)]);
+    const r = await check.run(ctx);
+    expect(r.findings.some((x) => x.id === 'hardcoded-credentials-found')).toBe(true);
+  });
+
+  it('ignores short values that are more likely stubs than secrets', async () => {
+    const ctx = makeCtx([apexClass('Stub', "public class Stub { String password = 'abc'; }")]);
+    const r = await check.run(ctx);
+    expect(r.findings[0].id).toBe('no-hardcoded-credentials');
+  });
+
+  // Test classes are excluded from the scan and from the cache, so fixtures full of fake
+  // credentials do not become findings.
+  it('excludes @IsTest classes from scanning', async () => {
+    const ctx = makeCtx([
+      apexClass('MyTest', `@IsTest public class MyTest { String password = 'hunter2hunter2'; }`),
+    ]);
+    const r = await check.run(ctx);
+    expect(r.findings[0].id).toBe('no-hardcoded-credentials');
+    // ...and reports zero scanned classes, not one.
+    expect(r.findings[0].detail).toContain('0 custom Apex classes');
+  });
+
+  it('populates the apexBodies cache with non-test classes only', async () => {
+    const ctx = makeCtx([
+      apexClass('Real', 'public class Real { }'),
+      apexClass('RealTest', '@IsTest public class RealTest { }'),
+    ]);
+    await check.run(ctx);
+    const cached = (ctx.cache as any).apexBodies as Array<{ name: string }>;
+    expect(cached.map((c) => c.name)).toEqual(['Real']);
+  });
+
+  it('flags a raw endpoint covered by nothing as MEDIUM', async () => {
+    const ctx = makeCtx(
+      [apexClass('Caller', "req.setEndpoint('https://api.vendor.com/v1/data');")],
+      { namedCredentialEndpoints: [], remoteSiteUrls: [] },
+    );
+    const r = await check.run(ctx);
+    const f = r.findings.find((x) => x.id === 'raw-endpoints-uncovered');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('MEDIUM');
+  });
+
+  it('does not flag an endpoint already covered by a Named Credential', async () => {
+    const ctx = makeCtx(
+      [apexClass('Caller', "req.setEndpoint('https://api.vendor.com/v1/data');")],
+      { namedCredentialEndpoints: ['https://api.vendor.com'], remoteSiteUrls: [] },
+    );
+    const r = await check.run(ctx);
+    expect(r.findings[0].id).toBe('no-hardcoded-credentials');
+  });
+
+  it('downgrades to LOW when only a Remote Site covers the endpoint', async () => {
+    const ctx = makeCtx(
+      [apexClass('Caller', "req.setEndpoint('https://api.vendor.com/v1/data');")],
+      { namedCredentialEndpoints: [], remoteSiteUrls: ['https://api.vendor.com'] },
+    );
+    const r = await check.run(ctx);
+    const f = r.findings.find((x) => x.id === 'raw-endpoints-remote-site-only');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('LOW');
+    expect(r.findings.some((x) => x.id === 'raw-endpoints-uncovered')).toBe(false);
+  });
+
+  it('matches coverage on host, not on the full path', async () => {
+    const ctx = makeCtx(
+      [apexClass('Caller', "req.setEndpoint('https://api.vendor.com/some/deep/path?q=1');")],
+      { namedCredentialEndpoints: ['https://api.vendor.com'], remoteSiteUrls: [] },
+    );
+    const r = await check.run(ctx);
+    expect(r.findings[0].id).toBe('no-hardcoded-credentials');
+  });
+
+  it('reports a class once as uncovered when it has both covered and uncovered endpoints', async () => {
+    const ctx = makeCtx(
+      [apexClass('Mixed', [
+        "req.setEndpoint('https://known.com/a');",
+        "req.setEndpoint('https://unknown.com/b');",
+      ].join('\n'))],
+      { namedCredentialEndpoints: ['https://known.com'], remoteSiteUrls: [] },
+    );
+    const r = await check.run(ctx);
+    // Uncovered wins: the class still has an unmanaged callout.
+    expect(r.findings.find((x) => x.id === 'raw-endpoints-uncovered')!.affectedItems)
+      .toHaveLength(1);
+    expect(r.findings.some((x) => x.id === 'raw-endpoints-remote-site-only')).toBe(false);
+  });
+
+  it('handles a missing cache without throwing', async () => {
+    const ctx = makeCtx([apexClass('Caller', "req.setEndpoint('https://api.vendor.com/x');")]);
+    const r = await check.run(ctx);
+    expect(r.findings.some((x) => x.id === 'raw-endpoints-uncovered')).toBe(true);
+  });
+
+  it('reports credentials and endpoints independently', async () => {
+    const ctx = makeCtx([
+      apexClass('Leaky', `String h = '${BEARER}';`),
+      apexClass('Caller', "req.setEndpoint('https://api.vendor.com/x');"),
+    ]);
+    const r = await check.run(ctx);
+    const ids = r.findings.map((f) => f.id);
+    expect(ids).toContain('hardcoded-credentials-found');
+    expect(ids).toContain('raw-endpoints-uncovered');
+    expect(ids).not.toContain('no-hardcoded-credentials');
+  });
+
+  // The patterns are module-level regexes with the /g flag, whose lastIndex persists between
+  // uses. If it were not reset, the second class scanned would be matched from the wrong
+  // offset and silently missed.
+  it('detects the same pattern in consecutive classes', async () => {
+    const ctx = makeCtx([
+      apexClass('One', `String h = '${BEARER}';`),
+      apexClass('Two', `String h = '${BEARER}';`),
+    ]);
+    const r = await check.run(ctx);
+    expect(r.findings.find((x) => x.id === 'hardcoded-credentials-found')!.affectedItems)
+      .toHaveLength(2);
+  });
+
+  it('excludes managed-package classes at the query level', async () => {
+    const ctx = makeCtx([]);
+    await check.run(ctx);
+    const q = (ctx.tooling.query as any).mock.calls[0][0] as string;
+    expect(q).toMatch(/FROM ApexClass/i);
+    expect(q).toMatch(/NamespacePrefix\s*=\s*null/i);
+  });
+});

--- a/test/unit/checks/impl/IpRestrictionsCheck.test.ts
+++ b/test/unit/checks/impl/IpRestrictionsCheck.test.ts
@@ -1,0 +1,183 @@
+import { jest } from '@jest/globals';
+import { IpRestrictionsCheck } from '../../../../src/checks/impl/IpRestrictionsCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+
+type Handler = (soql: string) => Promise<unknown[]>;
+
+function makeCtx(opts: { soql?: Handler; tooling?: Handler } = {}): AuditContext {
+  return {
+    soql: {
+      queryAll: (jest.fn() as any).mockImplementation((s: string) =>
+        opts.soql ? opts.soql(s) : Promise.resolve([]),
+      ),
+      query: jest.fn(),
+    } as any,
+    tooling: {
+      query: (jest.fn() as any).mockImplementation((s: string) =>
+        opts.tooling ? opts.tooling(s) : Promise.resolve([]),
+      ),
+      getRecord: jest.fn(),
+    } as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: {} as any,
+  } as any;
+}
+
+const admin = (id: string, profileId = '00eADMIN', profileName = 'System Administrator') => ({
+  Id: id, ProfileId: profileId, Username: `${id}@x.com`, Profile: { Name: profileName },
+});
+
+const range = (profileId: string, StartAddress: string, EndAddress: string) => ({
+  ProfileId: profileId, StartAddress, EndAddress,
+});
+
+const app = (Name: string, ipRelaxation?: string) => ({
+  Id: `0CiA${Name}`, Name,
+  Metadata: ipRelaxation ? { oauthConfig: { ipRelaxation } } : null,
+});
+
+/** Route SOQL by object. */
+const soqlRouter = (o: { admins?: unknown[]; ranges?: unknown[]; rangeError?: boolean }): Handler => (s) => {
+  if (/FROM User\b/i.test(s)) return Promise.resolve(o.admins ?? []);
+  if (/FROM ProfileLoginIpRange/i.test(s)) {
+    return o.rangeError ? Promise.reject(new Error('not queryable')) : Promise.resolve(o.ranges ?? []);
+  }
+  return Promise.resolve([]);
+};
+
+const toolingRouter = (o: { apps?: unknown[]; ranges?: unknown[]; appError?: boolean }): Handler => (s) => {
+  if (/FROM ConnectedApplication/i.test(s)) {
+    return o.appError ? Promise.reject(new Error('no metadata access')) : Promise.resolve(o.apps ?? []);
+  }
+  if (/FROM ProfileLoginIpRange/i.test(s)) return Promise.resolve(o.ranges ?? []);
+  return Promise.resolve([]);
+};
+
+describe('IpRestrictionsCheck', () => {
+  const check = new IpRestrictionsCheck();
+
+  it('passes when there is nothing to flag', async () => {
+    const r = await check.run(makeCtx({}));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('ip-restrictions-ok');
+    expect(r.findings[0].passed).toBe(true);
+  });
+
+  it('flags admin profiles with no IP ranges at all', async () => {
+    const r = await check.run(makeCtx({ soql: soqlRouter({ admins: [admin('a1')] }) }));
+    const f = r.findings.find((x) => x.id === 'admin-no-ip-restrictions');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('HIGH');
+    expect(f!.affectedItems?.[0].note).toContain('System Administrator');
+  });
+
+  it('clears an admin once their profile has any range', async () => {
+    const r = await check.run(makeCtx({
+      soql: soqlRouter({
+        admins: [admin('a1', '00eADMIN')],
+        ranges: [range('00eADMIN', '10.0.0.1', '10.0.0.50')],
+      }),
+    }));
+    expect(r.findings.some((x) => x.id === 'admin-no-ip-restrictions')).toBe(false);
+    expect(r.findings[0].id).toBe('ip-restrictions-ok');
+  });
+
+  it('only considers admins, via PermissionsModifyAllData on the profile', async () => {
+    const seen: string[] = [];
+    await check.run(makeCtx({ soql: (s) => { seen.push(s); return Promise.resolve([]); } }));
+    const q = seen.find((s) => /FROM User\b/i.test(s))!;
+    expect(q).toMatch(/Profile\.PermissionsModifyAllData\s*=\s*true/i);
+    expect(q).toMatch(/IsActive\s*=\s*true/i);
+  });
+
+  // ipRelaxation drives two different severities, and 'WhiteList' is the secure value.
+  it('flags ipRelaxation All as HIGH and Relax as MEDIUM', async () => {
+    const r = await check.run(makeCtx({
+      tooling: toolingRouter({ apps: [app('Bypasser', 'All'), app('Relaxer', 'Relax')] }),
+    }));
+    expect(r.findings.find((x) => x.id === 'connected-apps-bypass-ip')!.riskLevel).toBe('HIGH');
+    expect(r.findings.find((x) => x.id === 'connected-apps-relax-ip')!.riskLevel).toBe('MEDIUM');
+  });
+
+  it('does not flag apps that enforce the whitelist or declare nothing', async () => {
+    const r = await check.run(makeCtx({
+      tooling: toolingRouter({ apps: [app('Good', 'WhiteList'), app('NoMeta')] }),
+    }));
+    expect(r.findings[0].id).toBe('ip-restrictions-ok');
+  });
+
+  // SBS-AUTH-003: a range wide enough to be meaningless is worse than no range, because it
+  // looks like a control.
+  it.each([
+    ['10.0.0.0', '10.0.255.255', true],   // /16 exactly — 65,536 hosts, at the threshold
+    ['10.0.0.0', '10.0.254.255', false],  // one host short of the threshold
+    ['0.0.0.0', '0.0.0.1', true],         // tiny, but starts at 0.0.0.0
+    ['192.168.1.1', '192.168.1.254', false],
+  ])('range %s-%s flagged as broad: %s', async (start, end, expected) => {
+    const r = await check.run(makeCtx({
+      soql: soqlRouter({ ranges: [range('00eX', start, end)] }),
+    }));
+    expect(r.findings.some((x) => x.id === 'broad-ip-ranges')).toBe(expected);
+  });
+
+  it('names the profile on a broad range when it can resolve it', async () => {
+    const r = await check.run(makeCtx({
+      soql: soqlRouter({
+        admins: [admin('a1', '00eADMIN', 'Custom Admin')],
+        ranges: [range('00eADMIN', '0.0.0.0', '255.255.255.255')],
+      }),
+    }));
+    const f = r.findings.find((x) => x.id === 'broad-ip-ranges')!;
+    expect(f.affectedItems?.[0].label).toBe('Custom Admin');
+    expect(f.affectedItems?.[0].note).toContain('0.0.0.0');
+  });
+
+  it('falls back to the profile id when the name is unknown', async () => {
+    const r = await check.run(makeCtx({
+      soql: soqlRouter({ ranges: [range('00eUNKNOWN', '0.0.0.0', '255.255.255.255')] }),
+    }));
+    expect(r.findings.find((x) => x.id === 'broad-ip-ranges')!.affectedItems?.[0].label)
+      .toBe('00eUNKNOWN');
+  });
+
+  it('falls back to the Tooling API when ProfileLoginIpRange is not queryable via SOQL', async () => {
+    const r = await check.run(makeCtx({
+      soql: soqlRouter({ admins: [admin('a1', '00eADMIN')], rangeError: true }),
+      tooling: toolingRouter({ ranges: [range('00eADMIN', '10.0.0.1', '10.0.0.9')] }),
+    }));
+    // The fallback supplied the range, so the admin is not reported as unrestricted.
+    expect(r.findings.some((x) => x.id === 'admin-no-ip-restrictions')).toBe(false);
+  });
+
+  it('still reports admins when both range sources fail', async () => {
+    const r = await check.run(makeCtx({
+      soql: soqlRouter({ admins: [admin('a1')], rangeError: true }),
+      tooling: () => Promise.reject(new Error('nope')),
+    }));
+    expect(r.findings.some((x) => x.id === 'admin-no-ip-restrictions')).toBe(true);
+  });
+
+  it('survives connected-app metadata being inaccessible', async () => {
+    const r = await check.run(makeCtx({ tooling: toolingRouter({ appError: true }) }));
+    expect(r.findings[0].id).toBe('ip-restrictions-ok');
+  });
+
+  it('reports every category together when all are present', async () => {
+    const r = await check.run(makeCtx({
+      soql: soqlRouter({
+        admins: [admin('a1', '00eNORANGE')],
+        ranges: [range('00eOTHER', '0.0.0.0', '255.255.255.255')],
+      }),
+      tooling: toolingRouter({ apps: [app('B', 'All'), app('R', 'Relax')] }),
+    }));
+    expect(r.findings.map((f) => f.id)).toEqual(expect.arrayContaining([
+      'admin-no-ip-restrictions', 'connected-apps-bypass-ip',
+      'connected-apps-relax-ip', 'broad-ip-ranges',
+    ]));
+    expect(r.findings.some((f) => f.id === 'ip-restrictions-ok')).toBe(false);
+  });
+});

--- a/test/unit/checks/impl/IpRestrictionsCheck.test.ts
+++ b/test/unit/checks/impl/IpRestrictionsCheck.test.ts
@@ -149,21 +149,53 @@ describe('IpRestrictionsCheck', () => {
       soql: soqlRouter({ admins: [admin('a1', '00eADMIN')], rangeError: true }),
       tooling: toolingRouter({ ranges: [range('00eADMIN', '10.0.0.1', '10.0.0.9')] }),
     }));
-    // The fallback supplied the range, so the admin is not reported as unrestricted.
+    // The fallback supplied the range, so the admin is not reported as unrestricted...
     expect(r.findings.some((x) => x.id === 'admin-no-ip-restrictions')).toBe(false);
-  });
-
-  it('still reports admins when both range sources fail', async () => {
-    const r = await check.run(makeCtx({
-      soql: soqlRouter({ admins: [admin('a1')], rangeError: true }),
-      tooling: () => Promise.reject(new Error('nope')),
-    }));
-    expect(r.findings.some((x) => x.id === 'admin-no-ip-restrictions')).toBe(true);
-  });
-
-  it('survives connected-app metadata being inaccessible', async () => {
-    const r = await check.run(makeCtx({ tooling: toolingRouter({ appError: true }) }));
+    // ...and the run is not degraded, which is what distinguishes this from a failed lookup.
+    expect(r.findings.some((x) => x.id === 'ip-restrictions-ranges-unavailable')).toBe(false);
     expect(r.findings[0].id).toBe('ip-restrictions-ok');
+  });
+
+  /**
+   * Unreadable and absent are different facts. Treating an unreadable ProfileLoginIpRange as
+   * "no ranges configured" would report every admin as unrestricted — a HIGH finding the data
+   * cannot support — and an unreadable ConnectedApplication would let the check certify apps it
+   * never saw.
+   */
+  describe('unreadable sources are reported as unknown, not as fact', () => {
+    it('does not claim admins are unrestricted when ranges cannot be read', async () => {
+      const r = await check.run(makeCtx({
+        soql: soqlRouter({ admins: [admin('a1')], rangeError: true }),
+        tooling: () => Promise.reject(new Error('nope')),
+      }));
+      expect(r.findings.some((x) => x.id === 'admin-no-ip-restrictions')).toBe(false);
+      const f = r.findings.find((x) => x.id === 'ip-restrictions-ranges-unavailable')!;
+      expect(f.inconclusive).toBe(true);
+      // The admins are still named, so the gap is actionable rather than invisible.
+      expect(f.affectedItems?.[0].label).toBe('a1@x.com');
+    });
+
+    it('stays silent about ranges when there are no admins to evaluate', async () => {
+      const r = await check.run(makeCtx({
+        soql: soqlRouter({ admins: [], rangeError: true }),
+        tooling: () => Promise.reject(new Error('nope')),
+      }));
+      expect(r.findings.some((x) => x.id === 'ip-restrictions-ranges-unavailable')).toBe(false);
+    });
+
+    it('reports unreadable connected-app metadata as inconclusive', async () => {
+      const r = await check.run(makeCtx({ tooling: toolingRouter({ appError: true }) }));
+      const f = r.findings.find((x) => x.id === 'ip-restrictions-apps-unavailable')!;
+      expect(f.inconclusive).toBe(true);
+      // And crucially, no pass alongside it.
+      expect(r.findings.some((x) => x.id === 'ip-restrictions-ok')).toBe(false);
+    });
+
+    it('only passes when both sources were actually readable', async () => {
+      const readable = await check.run(makeCtx({}));
+      expect(readable.findings[0].id).toBe('ip-restrictions-ok');
+      expect(readable.findings[0].passed).toBe(true);
+    });
   });
 
   it('reports every category together when all are present', async () => {

--- a/test/unit/checks/impl/PublicGroupSharingCheck.test.ts
+++ b/test/unit/checks/impl/PublicGroupSharingCheck.test.ts
@@ -1,0 +1,160 @@
+import { jest } from '@jest/globals';
+import { PublicGroupSharingCheck } from '../../../../src/checks/impl/PublicGroupSharingCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+
+type Query = (soql: string) => Promise<{ records: unknown[] }>;
+
+function makeCtx(opts: {
+  groups?: unknown[];
+  query?: Query;
+  healthCloudInstalled?: boolean;
+} = {}): AuditContext {
+  return {
+    soql: {
+      queryAll: (jest.fn() as any).mockImplementation(() => Promise.resolve(opts.groups ?? [])),
+      query: (jest.fn() as any).mockImplementation((s: string) =>
+        opts.query ? opts.query(s) : Promise.resolve({ records: [] }),
+      ),
+    } as any,
+    tooling: {} as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: { healthCloudInstalled: opts.healthCloudInstalled } as any,
+  } as any;
+}
+
+const group = (Id = '00GALL', Name = 'All Internal Users') => ({ Id, Name, Type: 'AllInternal' });
+
+/** Return `cnt` shares on the named table, nothing elsewhere. */
+const sharesOn = (table: string, cnt: number, groupId = '00GALL'): Query => (s) =>
+  Promise.resolve(new RegExp(`FROM ${table}`, 'i').test(s)
+    ? { records: [{ UserOrGroupId: groupId, cnt }] }
+    : { records: [] });
+
+const ALL_TABLES = ['AccountShare', 'CaseShare', 'ContactShare', 'OpportunityShare'];
+
+describe('PublicGroupSharingCheck', () => {
+  const check = new PublicGroupSharingCheck();
+
+  it('passes when the org has no All Internal Users group', async () => {
+    const r = await check.run(makeCtx({ groups: [] }));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('public-group-sharing-none');
+    expect(r.findings[0].passed).toBe(true);
+  });
+
+  it('queries only for the AllInternal group type', async () => {
+    const ctx = makeCtx({});
+    await check.run(ctx);
+    expect((ctx.soql.queryAll as any).mock.calls[0][0]).toMatch(/Type\s*=\s*'AllInternal'/i);
+  });
+
+  it('flags sharing rules that target the group', async () => {
+    const r = await check.run(makeCtx({ groups: [group()], query: sharesOn('AccountShare', 7) }));
+    const f = r.findings.find((x) => x.id === 'public-group-sharing-exposure');
+    expect(f).toBeDefined();
+    expect(f!.affectedItems?.[0].label).toContain('AccountShare');
+    expect(f!.affectedItems?.[0].note).toContain('7');
+  });
+
+  it('counts distinct object types, not rule totals, in the title', async () => {
+    const r = await check.run(makeCtx({
+      groups: [group()],
+      query: (s) => Promise.resolve(
+        /FROM (AccountShare|CaseShare)/i.test(s)
+          ? { records: [{ UserOrGroupId: '00GALL', cnt: 3 }] }
+          : { records: [] },
+      ),
+    }));
+    expect(r.findings[0].title).toContain('2 object type(s)');
+  });
+
+  // Health Cloud means PHI, so the same exposure carries a higher severity.
+  it('raises severity from MEDIUM to HIGH when Health Cloud is installed', async () => {
+    const plain = await check.run(makeCtx({ groups: [group()], query: sharesOn('AccountShare', 1) }));
+    expect(plain.findings[0].riskLevel).toBe('MEDIUM');
+
+    const hc = await check.run(makeCtx({
+      groups: [group()], query: sharesOn('AccountShare', 1), healthCloudInstalled: true,
+    }));
+    expect(hc.findings[0].riskLevel).toBe('HIGH');
+  });
+
+  it('resolves the group name, falling back to its id', async () => {
+    const named = await check.run(makeCtx({
+      groups: [group('00GALL', 'Everyone Internal')], query: sharesOn('AccountShare', 1),
+    }));
+    expect(named.findings[0].affectedItems?.[0].label).toContain('Everyone Internal');
+
+    const unknown = await check.run(makeCtx({
+      groups: [group('00GALL')], query: sharesOn('AccountShare', 1, '00GOTHER'),
+    }));
+    expect(unknown.findings[0].affectedItems?.[0].label).toContain('00GOTHER');
+  });
+
+  it('restricts the count to rules, via RowCause', async () => {
+    const seen: string[] = [];
+    await check.run(makeCtx({
+      groups: [group()],
+      query: (s) => { seen.push(s); return Promise.resolve({ records: [] }); },
+    }));
+    expect(seen).toHaveLength(ALL_TABLES.length);
+    for (const s of seen) expect(s).toMatch(/RowCause\s*=\s*'SharingRule'/i);
+  });
+
+  /**
+   * "We found no sharing" and "we could not look" must not render as the same sentence. With
+   * every share table unreadable the check previously emitted a pass reading "No records shared
+   * to All Internal Users groups" — an assertion about data it never saw.
+   */
+  describe('unreadable share tables are not evidence of no sharing', () => {
+    it('is inconclusive when no share table could be queried', async () => {
+      const r = await check.run(makeCtx({
+        groups: [group()],
+        query: () => Promise.reject(new Error('INSUFFICIENT_ACCESS')),
+      }));
+      expect(r.findings).toHaveLength(1);
+      expect(r.findings[0].id).toBe('public-group-sharing-inconclusive');
+      expect(r.findings[0].inconclusive).toBe(true);
+      expect(r.findings[0].passed).toBeUndefined();
+      // It names what it could not read, so the gap is closable.
+      for (const table of ALL_TABLES) expect(r.findings[0].detail).toContain(table);
+    });
+
+    it('scopes the pass to the tables it could actually read', async () => {
+      const r = await check.run(makeCtx({
+        groups: [group()],
+        query: (s) => /FROM OpportunityShare/i.test(s)
+          ? Promise.reject(new Error('no access'))
+          : Promise.resolve({ records: [] }),
+      }));
+      const f = r.findings[0];
+      expect(f.id).toBe('public-group-sharing-none');
+      expect(f.passed).toBe(true);
+      // The claim is narrowed to what was checked, and names what was not.
+      expect(f.detail).toContain('OpportunityShare could not be queried');
+      expect(f.detail).toContain('AccountShare');
+    });
+
+    it('still reports a real exposure even when another table is unreadable', async () => {
+      const r = await check.run(makeCtx({
+        groups: [group()],
+        query: (s) => {
+          if (/FROM AccountShare/i.test(s)) return Promise.resolve({ records: [{ UserOrGroupId: '00GALL', cnt: 4 }] });
+          if (/FROM CaseShare/i.test(s)) return Promise.reject(new Error('no access'));
+          return Promise.resolve({ records: [] });
+        },
+      }));
+      expect(r.findings[0].id).toBe('public-group-sharing-exposure');
+    });
+
+    it('gives a clean, unqualified pass when everything was readable', async () => {
+      const r = await check.run(makeCtx({ groups: [group()] }));
+      expect(r.findings[0].passed).toBe(true);
+      expect(r.findings[0].detail).not.toContain('could not be queried');
+    });
+  });
+});

--- a/test/unit/checks/impl/SharingModelCheck.test.ts
+++ b/test/unit/checks/impl/SharingModelCheck.test.ts
@@ -1,0 +1,116 @@
+import { jest } from '@jest/globals';
+import { SharingModelCheck } from '../../../../src/checks/impl/SharingModelCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+
+type Entity = { QualifiedApiName: string; InternalSharingModel: string; ExternalSharingModel: string };
+
+function makeCtx(rows: Entity[] | Error): AuditContext {
+  return {
+    soql: {
+      queryAll: (jest.fn() as any).mockImplementation(() =>
+        rows instanceof Error ? Promise.reject(rows) : Promise.resolve(rows),
+      ),
+      query: jest.fn(),
+    } as any,
+    tooling: {} as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: {} as any,
+  } as any;
+}
+
+/** Private/ControlledByParent on both axes unless overridden. */
+const obj = (name: string, internal = 'Private', external = 'Private'): Entity => ({
+  QualifiedApiName: name, InternalSharingModel: internal, ExternalSharingModel: external,
+});
+
+describe('SharingModelCheck', () => {
+  const check = new SharingModelCheck();
+
+  it('passes when every object is Private on both axes', async () => {
+    const r = await check.run(makeCtx([obj('Account'), obj('Contact')]));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('sharing-model-secure');
+    expect(r.findings[0].passed).toBe(true);
+  });
+
+  it('treats ControlledByParent as restrictive, not as an exposure', async () => {
+    const r = await check.run(makeCtx([obj('Contact', 'ControlledByParent', 'ControlledByParent')]));
+    expect(r.findings[0].id).toBe('sharing-model-secure');
+  });
+
+  // External write is the most severe: portal and guest users can modify every record.
+  it.each(['ReadWrite', 'ReadWriteTransfer', 'FullAccess'])(
+    'flags external OWD %s as CRITICAL',
+    async (model) => {
+      const r = await check.run(makeCtx([obj('Account', 'Private', model)]));
+      const f = r.findings.find((x) => x.id === 'sharing-model-external-write');
+      expect(f).toBeDefined();
+      expect(f!.riskLevel).toBe('CRITICAL');
+      expect(f!.affectedItems?.[0].note).toContain(model);
+    },
+  );
+
+  it('flags external Read as HIGH', async () => {
+    const r = await check.run(makeCtx([obj('Account', 'Private', 'Read')]));
+    const f = r.findings.find((x) => x.id === 'sharing-model-external-read');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('HIGH');
+  });
+
+  it('flags internal write and internal read at their own severities', async () => {
+    const r = await check.run(makeCtx([
+      obj('Account', 'ReadWrite'),
+      obj('Contact', 'Read'),
+    ]));
+    expect(r.findings.find((x) => x.id === 'sharing-model-internal-write')!.riskLevel).toBe('MEDIUM');
+    expect(r.findings.find((x) => x.id === 'sharing-model-internal-read')!.riskLevel).toBe('LOW');
+  });
+
+  // Breadth is the signal: one permissive object is a mistake, three is a posture.
+  it('escalates internal write from MEDIUM to HIGH at three or more objects', async () => {
+    const two = await check.run(makeCtx([obj('Account', 'ReadWrite'), obj('Case', 'ReadWrite')]));
+    expect(two.findings.find((x) => x.id === 'sharing-model-internal-write')!.riskLevel).toBe('MEDIUM');
+
+    const three = await check.run(makeCtx([
+      obj('Account', 'ReadWrite'), obj('Case', 'ReadWrite'), obj('Lead', 'ReadWrite'),
+    ]));
+    expect(three.findings.find((x) => x.id === 'sharing-model-internal-write')!.riskLevel).toBe('HIGH');
+  });
+
+  it('reports internal and external exposure independently for one object', async () => {
+    const r = await check.run(makeCtx([obj('Account', 'ReadWrite', 'Read')]));
+    const ids = r.findings.map((f) => f.id);
+    expect(ids).toContain('sharing-model-internal-write');
+    expect(ids).toContain('sharing-model-external-read');
+    expect(ids).not.toContain('sharing-model-secure');
+  });
+
+  it('classifies each object once per axis, write taking precedence over read', async () => {
+    const r = await check.run(makeCtx([obj('Account', 'ReadWrite', 'ReadWrite')]));
+    expect(r.findings.some((x) => x.id === 'sharing-model-internal-read')).toBe(false);
+    expect(r.findings.some((x) => x.id === 'sharing-model-external-read')).toBe(false);
+  });
+
+  it('is inconclusive, not passing, when EntityDefinition is unreadable', async () => {
+    const r = await check.run(makeCtx(new Error('INSUFFICIENT_ACCESS')));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('sharing-model-inaccessible');
+    expect(r.findings[0].inconclusive).toBe(true);
+    // A permission failure must never be reported as a clean result.
+    expect(r.findings[0].passed).toBeUndefined();
+  });
+
+  it('scopes the query to the five standard objects', async () => {
+    const seen: string[] = [];
+    const ctx = makeCtx([]);
+    (ctx.soql.queryAll as any).mockImplementation((s: string) => { seen.push(s); return Promise.resolve([]); });
+    await check.run(ctx);
+    for (const name of ['Account', 'Contact', 'Opportunity', 'Case', 'Lead']) {
+      expect(seen[0]).toContain(`'${name}'`);
+    }
+  });
+});

--- a/test/unit/checks/impl/UsersAndAdminsCheck.test.ts
+++ b/test/unit/checks/impl/UsersAndAdminsCheck.test.ts
@@ -1,0 +1,167 @@
+import { jest } from '@jest/globals';
+import { UsersAndAdminsCheck } from '../../../../src/checks/impl/UsersAndAdminsCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+
+type Perms = Partial<{
+  ModifyAllData: boolean; ViewAllData: boolean; ManageUsers: boolean;
+  CustomizeApplication: boolean; AuthorApex: boolean;
+}>;
+
+/** One PermissionSetAssignment row: user `id` granted `perms` via permission set `via`. */
+const row = (id: string, perms: Perms, via = 'Admin_PS', ownedByProfile = false) => ({
+  Assignee: { Id: id, Username: `${id}@x.com`, Name: id, Profile: { Name: 'System Administrator' } },
+  PermissionSet: {
+    Name: via,
+    IsOwnedByProfile: ownedByProfile,
+    PermissionsModifyAllData: perms.ModifyAllData ?? false,
+    PermissionsViewAllData: perms.ViewAllData ?? false,
+    PermissionsManageUsers: perms.ManageUsers ?? false,
+    PermissionsCustomizeApplication: perms.CustomizeApplication ?? false,
+    PermissionsAuthorApex: perms.AuthorApex ?? false,
+  },
+});
+
+function makeCtx(rows: unknown[], totalActiveUsers = 50): AuditContext {
+  return {
+    soql: {
+      queryAll: jest.fn(),
+      query: (jest.fn() as any).mockImplementation((s: string) =>
+        /COUNT\(\)/i.test(s)
+          ? Promise.resolve({ totalSize: totalActiveUsers, records: [] })
+          : Promise.resolve({ totalSize: rows.length, records: rows }),
+      ),
+    } as any,
+    tooling: {} as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: {} as any,
+  } as any;
+}
+
+/** n distinct users each holding the given permissions. */
+const users = (n: number, perms: Perms) =>
+  Array.from({ length: n }, (_, i) => row(`u${i}`, perms));
+
+describe('UsersAndAdminsCheck', () => {
+  const check = new UsersAndAdminsCheck();
+
+  it('always reports the Modify All / View All population, even at zero', async () => {
+    const r = await check.run(makeCtx([]));
+    const ids = r.findings.map((f) => f.id);
+    expect(ids).toContain('users-modify-all-data');
+    expect(ids).toContain('users-view-all-data');
+    expect(r.findings.find((f) => f.id === 'users-modify-all-data')!.riskLevel).toBe('LOW');
+  });
+
+  it('returns org metrics alongside the findings', async () => {
+    const r = await check.run(makeCtx(users(2, { ModifyAllData: true }), 137));
+    expect(r.metrics).toMatchObject({
+      totalActiveUsers: 137,
+      modifyAllDataUsersCount: 2,
+      viewAllDataUsersCount: 0,
+    });
+  });
+
+  // Severity tracks how many people hold the permission, so the boundaries matter.
+  it.each([
+    [3, 'LOW'], [4, 'HIGH'], [5, 'HIGH'], [6, 'CRITICAL'],
+  ])('rates %i Modify All Data users as %s', async (n, expected) => {
+    const r = await check.run(makeCtx(users(n, { ModifyAllData: true })));
+    expect(r.findings.find((f) => f.id === 'users-modify-all-data')!.riskLevel).toBe(expected);
+  });
+
+  it.each([
+    [5, 'LOW'], [6, 'MEDIUM'], [10, 'MEDIUM'], [11, 'HIGH'],
+  ])('rates %i View All Data users as %s', async (n, expected) => {
+    const r = await check.run(makeCtx(users(n, { ViewAllData: true })));
+    expect(r.findings.find((f) => f.id === 'users-view-all-data')!.riskLevel).toBe(expected);
+  });
+
+  it('counts a user once even when several permission sets grant the same permission', async () => {
+    const r = await check.run(makeCtx([
+      row('same', { ModifyAllData: true }, 'PS_One'),
+      row('same', { ModifyAllData: true }, 'PS_Two'),
+      row('same', { ModifyAllData: true }, 'PS_Three'),
+    ]));
+    const f = r.findings.find((x) => x.id === 'users-modify-all-data')!;
+    expect(f.title).toContain('1 user(s)');
+    // LOW, because it is one person — not three.
+    expect(f.riskLevel).toBe('LOW');
+    // Every grant path is still listed, so the reader can see where it comes from.
+    expect(f.affectedItems).toHaveLength(3);
+  });
+
+  it('flags the super-admin combination only when one user holds all three', async () => {
+    const all = await check.run(makeCtx([
+      row('boss', { ModifyAllData: true, ViewAllData: true, ManageUsers: true }),
+    ]));
+    const f = all.findings.find((x) => x.id === 'users-super-admin-combo');
+    expect(f).toBeDefined();
+    expect(f!.riskLevel).toBe('CRITICAL');
+
+    const twoOfThree = await check.run(makeCtx([
+      row('boss', { ModifyAllData: true, ViewAllData: true }),
+    ]));
+    expect(twoOfThree.findings.some((x) => x.id === 'users-super-admin-combo')).toBe(false);
+  });
+
+  it('does not manufacture a super-admin from three separate people', async () => {
+    const r = await check.run(makeCtx([
+      row('a', { ModifyAllData: true }),
+      row('b', { ViewAllData: true }),
+      row('c', { ManageUsers: true }),
+    ]));
+    expect(r.findings.some((x) => x.id === 'users-super-admin-combo')).toBe(false);
+  });
+
+  it('assembles the combination across different permission sets for one user', async () => {
+    const r = await check.run(makeCtx([
+      row('boss', { ModifyAllData: true }, 'PS_Data'),
+      row('boss', { ViewAllData: true }, 'PS_Read'),
+      row('boss', { ManageUsers: true }, 'PS_Ident'),
+    ]));
+    expect(r.findings.some((x) => x.id === 'users-super-admin-combo')).toBe(true);
+  });
+
+  it('reports Customize Application and Author Apex only above their thresholds', async () => {
+    const quiet = await check.run(makeCtx([
+      ...users(5, { CustomizeApplication: true }),
+      ...users(3, { AuthorApex: true }),
+    ]));
+    expect(quiet.findings.some((f) => f.id === 'users-customize-application')).toBe(false);
+    expect(quiet.findings.some((f) => f.id === 'users-author-apex')).toBe(false);
+
+    const loud = await check.run(makeCtx([
+      ...Array.from({ length: 6 }, (_, i) => row(`c${i}`, { CustomizeApplication: true })),
+      ...Array.from({ length: 4 }, (_, i) => row(`a${i}`, { AuthorApex: true })),
+    ]));
+    expect(loud.findings.some((f) => f.id === 'users-customize-application')).toBe(true);
+    expect(loud.findings.some((f) => f.id === 'users-author-apex')).toBe(true);
+  });
+
+  it('names the grant path so a reader can act on it', async () => {
+    const viaPs = await check.run(makeCtx([row('u', { ModifyAllData: true }, 'Data_Admin_PS', false)]));
+    expect(viaPs.findings.find((f) => f.id === 'users-modify-all-data')!.affectedItems?.[0].note)
+      .toBe('via: Data_Admin_PS');
+
+    const viaProfile = await check.run(makeCtx([row('u', { ModifyAllData: true }, 'X', true)]));
+    expect(viaProfile.findings.find((f) => f.id === 'users-modify-all-data')!.affectedItems?.[0].note)
+      .toBe('via: Profile');
+  });
+
+  it('excludes frozen and inactive users in the query itself', async () => {
+    const seen: string[] = [];
+    const ctx = makeCtx([]);
+    (ctx.soql.query as any).mockImplementation((s: string) => {
+      seen.push(s);
+      return Promise.resolve({ totalSize: 0, records: [] });
+    });
+    await check.run(ctx);
+    const psaQuery = seen.find((s) => /FROM PermissionSetAssignment/i.test(s))!;
+    expect(psaQuery).toMatch(/Assignee\.IsActive\s*=\s*true/i);
+    expect(psaQuery).toMatch(/IsFrozen\s*=\s*true/i);
+  });
+});


### PR DESCRIPTION
Test coverage for the untested checks, and the reporting-accuracy fixes that writing those tests uncovered.

**Coverage 62.76% → 70.58%. Suite 685 → 807 tests. Untested checks 57 → 49.**

## Why this started

Assessing the repo for the silver badge turned up that **57 of 88 checks had no unit test file**. Their 7–13% coverage was incidental execution via registry and integration tests — the finding-producing logic was unexercised. Eight are now covered, chosen by severity rather than ease.

## The part that matters more than the coverage number

A security report has to distinguish **"we checked and it's fine"** from **"we couldn't check"**. A sweep for checks that can reach `passed: true` after a silently caught query failure flagged 17 candidates. I verified each rather than mass-editing — the heuristic over-reports, and `GuestUserAccessCheck` is a confirmed false positive, since its pass returns before the try/catch.

**Three are real and fixed:**

| Check | What it claimed |
|---|---|
| `field-level-security` | "Sensitive custom fields appear appropriately restricted", `passed: true`, in **three** states where it analysed nothing — on a check that looks for SSNs, bank accounts and medical records |
| `ip-restrictions` | Failed in **both directions**: an unreadable `ProfileLoginIpRange` was read as "no ranges configured", **inventing a HIGH finding** against every admin; an unreadable `ConnectedApplication` let it **certify apps it never saw** |
| `public-group-sharing` | "No records shared to All Internal Users groups" with all four share tables unqueryable |

One failure mode fabricates a finding, the other fabricates an assurance. Both are now reported as inconclusive, naming what could not be evaluated so the gap is closable.

**The fix is not blanket-inconclusive.** Where partial data exists the claim is *scoped* — `public-group-sharing` now states which tables it checked and which it couldn't, because an object may be absent by org edition rather than by permission. Turning every partial read into an alarm would be its own inaccuracy.

## Two further findings from writing the tests

**A latent regex-state bug class.** The credential patterns in `hardcoded-credentials` are module-level regexes carrying `/g`, whose `lastIndex` persists between uses. The check resets it, but nothing tested that. There is now a case that fails if the reset is removed — the same pattern in two consecutive classes must match twice. That failure mode is silent under-reporting, not an error.

**A detection boundary, now deliberate.** Apex's usual `req.setHeader('Authorization', 'Bearer ' + token)` does not match the Authorization pattern, because the comma breaks it. That is correct — a token in a variable is not hardcoded — and detection falls to the Bearer/Basic patterns, which need a literal long enough to be a real secret. Both cases are tested so nobody "fixes" the pattern and floods reports with false positives.

## What the tests assert

Behaviour, not lines. Severity boundaries are tested either side (3/4 and 5/6 Modify All Data users; exactly 10 vs 11 permission sets; a /16 exactly vs one host short). Query shapes are asserted where correctness depends on them — guests filtered to `IsActive = true`, share counts restricted to `RowCause = 'SharingRule'`, Health Cloud objects entering scope only when the cache says so, and managed packages excluded at the query level.

Certificate fixtures compute expiry relative to `Date.now()` rather than pinning a date, so they cannot rot.

## Files covered

`guest-user-access`, `sharing-model`, `field-level-security`, `users-and-admins`, `certificate-expiry`, `ip-restrictions`, `hardcoded-credentials`, `public-group-sharing` — all 98–100%.

## Verification

`build`, `typecheck`, `test` all exit 0 — 98 suites / 807 tests.

Remaining to the silver 80% threshold: **471 statements**, roughly 9–11 more files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
