### PR TITLE
fix(fail-on): stop every INFO finding counting as a threshold violation (v1.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,27 @@ published note and carries the signed provenance attestation and CycloneDX SBOM 
 
 Merged to `main`, not yet released.
 
+## [v1.9.0](https://github.com/cclabsnz/sf-audit-plugin/releases/tag/v1.9.0) — 2026-09-07
+
+Two compliance catalogs, three attack chains, and a restructured documentation set — but
+the reason to upgrade is the `--fail-on` fix. That flag never worked: any pipeline using it
+exited 1 on every run, whatever the org looked like. If you gate CI on this plugin, this is
+the release that makes the gate mean something.
+
+### Fixed
+
+- **`--fail-on` fired on every audit.** The threshold comparison ranked findings with
+  `ORDER.indexOf(level) <= threshold`, and `INFO` is absent from that order, so it
+  scored `-1` — more severe than `CRITICAL` at every threshold. Because passing and
+  inconclusive checks both carry `INFO`, and every audit produces passes, any pipeline
+  using `--fail-on` exited 1 regardless of what was actually found. Gateable severities
+  are now matched explicitly, and passed/inconclusive findings can never be violations.
+
 ### Added
+
+- **`--fail-on-inconclusive`** — exit 3 when a check could not gather evidence, so CI can
+  tell a clean org apart from an audit user that could not see enough to judge. Off by
+  default. A finding at or above `--fail-on` still takes precedence and exits 1.
 
 - **HIPAA Security Rule and GDPR compliance catalogs** — 26 source-verified controls, taking the
   catalog from 93 to 119. HIPAA pins the operative 2013 Omnibus rule (the 2025 NPRM remains

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ check id.
 |------|---------|---|
 | `--format` / `-f` | `html` | `html`, `md`, `json`, `executive` — comma-separated |
 | `--fail-on` | (none) | Exit 1 if any finding is at or above `CRITICAL`/`HIGH`/`MEDIUM`/`LOW`. For CI |
+| `--fail-on-inconclusive` | `false` | Exit 3 if any check could not gather evidence. For CI |
 | `--checks` | *(all)* | Run only these check ids |
 | `--frameworks` | `universal` | Compliance matrix scope for the executive report |
 
@@ -58,9 +59,28 @@ check id.
 # Fail a pipeline on HIGH or worse
 sf audit security --target-org myOrg --fail-on HIGH
 
+# Also fail if the audit user could not see enough to judge
+sf audit security --target-org myOrg --fail-on HIGH --fail-on-inconclusive
+
 # Branded, client-ready PDF-able report
 sf audit security --target-org myOrg --format executive --prepared-for "Acme Health"
+
+# Machine-readable: result on stdout, progress logging suppressed
+sf audit security --target-org myOrg --json
 ```
+
+### Exit codes
+
+| Code | Meaning |
+|-----:|---------|
+| `0` | Audit completed; nothing the caller asked to fail on |
+| `1` | Findings at or above `--fail-on` |
+| `2` | The audit could not run — authentication, connection, or bad flags |
+| `3` | Audit ran, but checks could not gather evidence (`--fail-on-inconclusive` only) |
+
+A definite finding outranks unknown coverage: when both apply you get `1`, and the
+inconclusive count is still in the report body. `3` exists so a pipeline can tell
+"this org is fine" apart from "the audit user could not see enough to judge".
 
 All twelve flags, more examples, and what the executive report contains:
 **[docs/COMMANDS.md](docs/COMMANDS.md)**.

--- a/messages/audit.security.md
+++ b/messages/audit.security.md
@@ -22,6 +22,12 @@ Directory to write the report file. Defaults to the current directory.
 Exit with code 1 if any finding is at or above this severity level.
 Options: CRITICAL, HIGH, MEDIUM, LOW
 
+## fail-on-inconclusive
+
+Exit with code 3 if any check could not gather evidence because the audit user lacked
+the required permission. Off by default, so existing pipelines are unaffected. A finding
+at or above `--fail-on` takes precedence and still exits 1.
+
 ## checks
 
 Comma-separated check IDs to run instead of all checks (e.g. `hardcoded-credentials,apex-sharing`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cclabsnz/sf-audit",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Read-only Salesforce security audit for the sf CLI: 88 checks, attack-chain correlation, A-F risk grading, and compliance mapping to OWASP, SOC 2, ISO 27001, NZISM and more.",
   "keywords": [
     "salesforce",

--- a/src/commands/audit/security.ts
+++ b/src/commands/audit/security.ts
@@ -15,6 +15,7 @@ import { resolveFrameworks } from '../../compliance/resolve.js';
 import { buildAuditContext, resolveOrgInfo } from '../../lib/wire.js';
 import { loadScoringConfig } from '../../findings/loadScoringConfig.js';
 import { HistoryStore } from '../../history/HistoryStore.js';
+import { EXIT_FINDINGS, EXIT_INCONCLUSIVE, resolveExitCode, violationsFor } from '../../findings/exitCode.js';
 
 const RENDERERS: Record<string, AuditRenderer> = {
   html: new HtmlRenderer(),
@@ -47,6 +48,10 @@ export default class SecurityAuditCommand extends SfCommand<AuditResult> {
     'fail-on': Flags.string({
       summary: 'Exit with code 1 if any finding is at or above this severity.',
       options: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'],
+    }),
+    'fail-on-inconclusive': Flags.boolean({
+      summary: 'Exit with code 3 if any check could not gather evidence. Off by default.',
+      default: false,
     }),
     checks: Flags.string({
       summary: 'Comma-separated check IDs to run. Omit to run all checks.',
@@ -130,9 +135,7 @@ export default class SecurityAuditCommand extends SfCommand<AuditResult> {
     this.log('');
     this.log('  Deep dives: https://softwareinsights.dev   ·   Remediation help: https://cloudcounsel.co.nz');
 
-    if (flags['fail-on']) {
-      this.handleFailOn(result, flags['fail-on'] as RiskLevel);
-    }
+    this.applyExitCode(result, flags['fail-on'] as RiskLevel | undefined, flags['fail-on-inconclusive']);
 
     return result;
   }
@@ -200,16 +203,38 @@ export default class SecurityAuditCommand extends SfCommand<AuditResult> {
     this.log('─────────────────────────────');
   }
 
-  private handleFailOn(result: AuditResult, failOn: RiskLevel): void {
-    const ORDER: RiskLevel[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'];
-    const threshold = ORDER.indexOf(failOn);
-    const violations = result.findings.filter((f) => ORDER.indexOf(f.riskLevel) <= threshold);
-    if (violations.length > 0) {
+  /**
+   * Set the process exit code from the audit outcome.
+   *
+   * 0 clean · 1 findings at or above --fail-on · 3 inconclusive checks when the
+   * caller passed --fail-on-inconclusive. Anything that stops the audit running
+   * at all surfaces as oclif's own error exit instead.
+   *
+   * The result is always returned, so `--json` still yields the full report
+   * alongside a non-zero exit.
+   */
+  private applyExitCode(result: AuditResult, failOn: RiskLevel | undefined, failOnInconclusive: boolean): void {
+    const code = resolveExitCode(result.findings, { failOn, failOnInconclusive });
+
+    if (code === EXIT_FINDINGS && failOn !== undefined) {
+      const violations = violationsFor(result.findings, failOn);
       this.log(`\nFail-on threshold: ${failOn}, ${violations.length} finding${violations.length !== 1 ? 's' : ''} at or above threshold:`);
       for (const f of violations) {
         this.log(`  [${f.riskLevel}] ${f.title}`);
       }
-      this.exit(1);
     }
+
+    if (code === EXIT_INCONCLUSIVE) {
+      const blind = result.findings.filter((f) => f.inconclusive === true);
+      this.log(`\n${blind.length} check${blind.length !== 1 ? 's' : ''} could not gather evidence:`);
+      for (const f of blind) {
+        this.log(`  [inconclusive] ${f.title}`);
+      }
+    }
+
+    // Deliberately not this.exit(): that throws an ExitError, which SfCommand.catch()
+    // renders as the JSON error envelope, discarding the audit result under --json.
+    // Setting the code lets run() return the report and still exit non-zero.
+    if (code !== 0) process.exitCode = code;
   }
 }

--- a/src/findings/exitCode.ts
+++ b/src/findings/exitCode.ts
@@ -1,0 +1,54 @@
+import type { RiskLevel } from '@cclabsnz/sf-core';
+import type { Finding } from './Finding.js';
+
+/** Audit completed; nothing the caller asked to fail on. */
+export const EXIT_OK = 0;
+/** Findings at or above the --fail-on threshold. */
+export const EXIT_FINDINGS = 1;
+/** Audit ran, but checks could not gather evidence. Only when --fail-on-inconclusive is set. */
+export const EXIT_INCONCLUSIVE = 3;
+
+/**
+ * Severity order, most severe first. INFO is deliberately absent: it is not a
+ * severity a caller can gate on, it is the level carried by passing and
+ * inconclusive findings.
+ */
+const ORDER: RiskLevel[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'];
+
+export interface ExitOptions {
+  failOn?: RiskLevel;
+  failOnInconclusive?: boolean;
+}
+
+/**
+ * Findings at or above `failOn`.
+ *
+ * Ranks are compared only after confirming the level is gateable. Testing
+ * `ORDER.indexOf(level) <= threshold` alone treats INFO (index -1) as more severe
+ * than CRITICAL, which made every passing check a violation.
+ */
+export function violationsFor(findings: Finding[], failOn: RiskLevel): Finding[] {
+  const threshold = ORDER.indexOf(failOn);
+  if (threshold < 0) return [];
+  return findings.filter((f) => {
+    if (f.passed === true || f.inconclusive === true) return false;
+    const rank = ORDER.indexOf(f.riskLevel);
+    return rank >= 0 && rank <= threshold;
+  });
+}
+
+/**
+ * The process exit code for a completed audit.
+ *
+ * A definite finding outranks unknown coverage: when both apply the caller gets
+ * EXIT_FINDINGS, and the inconclusive count is still carried in the report body.
+ */
+export function resolveExitCode(findings: Finding[], opts: ExitOptions): number {
+  if (opts.failOn !== undefined && violationsFor(findings, opts.failOn).length > 0) {
+    return EXIT_FINDINGS;
+  }
+  if (opts.failOnInconclusive === true && findings.some((f) => f.inconclusive === true)) {
+    return EXIT_INCONCLUSIVE;
+  }
+  return EXIT_OK;
+}

--- a/test/unit/commands/json-flag.test.ts
+++ b/test/unit/commands/json-flag.test.ts
@@ -1,0 +1,41 @@
+import AuditAppsCommand from '../../../src/commands/audit/apps.js';
+import AuditDiffCommand from '../../../src/commands/audit/diff.js';
+import AuditHistoryCommand from '../../../src/commands/audit/history.js';
+import AuditListCommand from '../../../src/commands/audit/list.js';
+import SecurityAuditCommand from '../../../src/commands/audit/security.js';
+import AuditTimelineCommand from '../../../src/commands/audit/timeline.js';
+import AuditEventsPullCommand from '../../../src/commands/audit/events/pull.js';
+
+/**
+ * Agent-drivability invariant.
+ *
+ * Every command already returns a typed, serialisable result from run(). oclif will
+ * emit that result as JSON on stdout — suppressing the human progress logging — but
+ * only when the command opts in via `enableJsonFlag`. Without it there is no
+ * machine-readable surface at all: a caller has to scrape progress lines off stdout
+ * and race the report file write.
+ *
+ * This is the gate that keeps `--json` working on every command, including ones
+ * added later.
+ */
+
+const COMMANDS = [
+  ['audit security', SecurityAuditCommand],
+  ['audit list', AuditListCommand],
+  ['audit history', AuditHistoryCommand],
+  ['audit diff', AuditDiffCommand],
+  ['audit apps', AuditAppsCommand],
+  ['audit timeline', AuditTimelineCommand],
+  ['audit events pull', AuditEventsPullCommand],
+] as const;
+
+describe('--json is available on every command', () => {
+  it('covers every command the plugin ships', () => {
+    // Guards against the suite passing vacuously if the list above is gutted.
+    expect(COMMANDS).toHaveLength(7);
+  });
+
+  it.each(COMMANDS)('%s enables the json flag', (_name, Command) => {
+    expect(Command.enableJsonFlag).toBe(true);
+  });
+});

--- a/test/unit/findings/exitCode.test.ts
+++ b/test/unit/findings/exitCode.test.ts
@@ -1,0 +1,78 @@
+import type { RiskLevel } from '@cclabsnz/sf-core';
+import type { Finding } from '../../../src/findings/Finding.js';
+import { EXIT_FINDINGS, EXIT_INCONCLUSIVE, EXIT_OK, resolveExitCode, violationsFor } from '../../../src/findings/exitCode.js';
+
+const f = (riskLevel: RiskLevel, extra: Partial<Finding> = {}): Finding => ({
+  id: `${riskLevel}-${Math.random()}`,
+  category: 'Test',
+  riskLevel,
+  title: `${riskLevel} finding`,
+  detail: 'detail',
+  remediation: 'remediation',
+  ...extra,
+});
+
+describe('violationsFor', () => {
+  it('does not treat INFO findings as violations at the CRITICAL threshold', () => {
+    // ORDER.indexOf('INFO') is -1, and -1 <= threshold is true for every threshold.
+    // That made every passing check a violation, so --fail-on fired on every audit.
+    expect(violationsFor([f('INFO')], 'CRITICAL')).toHaveLength(0);
+  });
+
+  it('does not treat INFO findings as violations at any threshold', () => {
+    for (const failOn of ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as RiskLevel[]) {
+      expect(violationsFor([f('INFO')], failOn)).toHaveLength(0);
+    }
+  });
+
+  it('never counts a passed finding as a violation', () => {
+    expect(violationsFor([f('INFO', { passed: true })], 'LOW')).toHaveLength(0);
+  });
+
+  it('never counts an inconclusive finding as a violation', () => {
+    expect(violationsFor([f('INFO', { inconclusive: true })], 'LOW')).toHaveLength(0);
+  });
+
+  it('counts a finding at the threshold', () => {
+    expect(violationsFor([f('HIGH')], 'HIGH')).toHaveLength(1);
+  });
+
+  it('counts a finding above the threshold', () => {
+    expect(violationsFor([f('CRITICAL')], 'HIGH')).toHaveLength(1);
+  });
+
+  it('does not count a finding below the threshold', () => {
+    expect(violationsFor([f('MEDIUM')], 'HIGH')).toHaveLength(0);
+  });
+});
+
+describe('resolveExitCode', () => {
+  it('is 0 when no threshold is requested, even with a CRITICAL finding', () => {
+    expect(resolveExitCode([f('CRITICAL')], {})).toBe(EXIT_OK);
+  });
+
+  it('is 0 when findings sit below the threshold', () => {
+    expect(resolveExitCode([f('MEDIUM')], { failOn: 'HIGH' })).toBe(EXIT_OK);
+  });
+
+  it('is 1 when a finding meets the threshold', () => {
+    expect(resolveExitCode([f('HIGH')], { failOn: 'HIGH' })).toBe(EXIT_FINDINGS);
+  });
+
+  it('is 0 for inconclusive findings when the caller has not opted in', () => {
+    expect(resolveExitCode([f('INFO', { inconclusive: true })], {})).toBe(EXIT_OK);
+  });
+
+  it('is 3 for inconclusive findings when the caller opts in', () => {
+    expect(resolveExitCode([f('INFO', { inconclusive: true })], { failOnInconclusive: true })).toBe(EXIT_INCONCLUSIVE);
+  });
+
+  it('prefers the definite finding over the unknown when both apply', () => {
+    const findings = [f('CRITICAL'), f('INFO', { inconclusive: true })];
+    expect(resolveExitCode(findings, { failOn: 'HIGH', failOnInconclusive: true })).toBe(EXIT_FINDINGS);
+  });
+
+  it('is 0 for a clean audit of passes only', () => {
+    expect(resolveExitCode([f('INFO', { passed: true })], { failOn: 'LOW', failOnInconclusive: true })).toBe(EXIT_OK);
+  });
+});

--- a/test/unit/invariants/exit-preserves-json.test.ts
+++ b/test/unit/invariants/exit-preserves-json.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * A non-zero exit must not destroy the JSON result.
+ *
+ * `this.exit(n)` throws an ExitError. SfCommand.catch() turns any thrown error into
+ * the JSON *error* envelope, so a command that exits this way under `--json` returns
+ * an error instead of its result — the caller loses the audit report precisely when
+ * findings exist and it matters most.
+ *
+ * Setting `process.exitCode` instead lets run() return normally: oclif prints the
+ * result, and the process still exits non-zero.
+ */
+
+const SECURITY_CMD = join(process.cwd(), 'src/commands/audit/security.ts');
+
+/** Strip block and line comments so the scan reads code, not prose about code. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+describe('non-zero exit preserves the JSON result', () => {
+  const source = stripComments(readFileSync(SECURITY_CMD, 'utf-8'));
+
+  it('reads the command source', () => {
+    // Vacuity guard: a moved or renamed file must fail loudly, not pass silently.
+    expect(source.length).toBeGreaterThan(1000);
+    expect(source).toContain('resolveExitCode');
+  });
+
+  it('does not call this.exit() to signal audit outcome', () => {
+    expect(source).not.toMatch(/this\.exit\(/);
+  });
+
+  it('sets process.exitCode instead', () => {
+    expect(source).toMatch(/process\.exitCode\s*=/);
+  });
+});


### PR DESCRIPTION
## The bug

`--fail-on` has never gated anything. The filter ranked findings with:

```js
ORDER.indexOf(f.riskLevel) <= threshold   // ORDER = CRITICAL, HIGH, MEDIUM, LOW
```

`INFO` is absent from `ORDER`, so `indexOf` returns `-1`, and `-1 <= threshold` holds at
every threshold — `INFO` sorted as *more severe than* `CRITICAL`. Passing checks and
inconclusive checks both carry `INFO`, and every audit emits passes, so **any pipeline
running `--fail-on` exited 1 on every run regardless of what the audit found.**

A gate that always fails is a gate nobody can act on.

## The fix

Severity resolution moves to `src/findings/exitCode.ts`, which matches gateable levels
explicitly and excludes `passed` / `inconclusive` findings from ever being violations.

## Added: `--fail-on-inconclusive`

Exit `3` when a check could not gather evidence, so CI can tell a clean org apart from an
audit user that could not see enough to judge. Default off, so existing pipelines are
unaffected. A finding at or above `--fail-on` still takes precedence and exits 1.

| Code | Meaning |
|-----:|---------|
| `0` | Audit completed; nothing the caller asked to fail on |
| `1` | Findings at or above `--fail-on` |
| `2` | The audit could not run — auth, connection, or bad flags |
| `3` | Ran, but checks could not gather evidence (`--fail-on-inconclusive` only) |

## `--json` no longer loses the report

The exit is signalled with `process.exitCode` rather than `this.exit()`. `this.exit()`
throws an `ExitError`, which `SfCommand.catch()` renders as the JSON *error* envelope — so
under `--json` the caller lost the audit report precisely when findings existed and it
mattered most. Returning normally means `--json` now yields the full report alongside a
non-zero exit.

`test/unit/invariants/exit-preserves-json.test.ts` pins this: it fails if `this.exit(`
reappears in the command. Verified by mutation — reintroducing the call turns the test red.

## Also

Pins `--json` availability across all seven commands. `SfCommand` already defaults
`enableJsonFlag` to `true`; this guards against a future command extending oclif's
`Command` directly and silently losing the machine-readable surface.

## Release

Cuts **v1.9.0**. Minor rather than patch because of the new flag. The release also carries
what was already sitting in `[Unreleased]`: HIPAA/GDPR catalogs, three attack chains, and
the documentation restructure.

## Verification

- `pnpm run build` — clean
- `pnpm test` — **1132 passed / 117 suites** (22 new)
- `pnpm audit --prod --audit-level high` — no known vulnerabilities
- `pnpm run lint` — clean