### PR TITLE
feat(agent): preflight command and --digest for programmatic callers (v1.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ published note and carries the signed provenance attestation and CycloneDX SBOM 
 
 Merged to `main`, not yet released.
 
+## [v1.10.0](https://github.com/cclabsnz/sf-audit-plugin/releases/tag/v1.10.0) — 2026-09-07
+
+Two additions for callers that drive this plugin programmatically: find out what the audit
+user can actually see *before* spending a run, and get the result back without paying for
+the half of it that is passing checks and prose.
+
+### Added
+
+- **`sf audit preflight`** — reports what this audit user will and will not be able to
+  establish, before a run is spent. Reads the caller's effective permissions from
+  `UserPermissionAccess` in a single query and names the checks that will return
+  inconclusive, with the grants that would fix them. The audit itself can only report a
+  permission gap *after* it has come back blind; this asks the same question up front.
+  The affected-check lists are derived from the registry's declared cache wiring rather
+  than hand-maintained, so a check added later is covered without editing the map.
+
+- **`--digest`** on `sf audit security` — a compact result for programmatic callers.
+  Passing checks are counted but not listed, `detail` prose gives way to `remediation`,
+  and affected-item lists — unbounded, and the bulk of a large org's report — collapse to
+  a count plus a three-item sample. Attack chains survive intact. Composes with `--json`,
+  so an agent gets one command and compact stdout.
+
 ## [v1.9.0](https://github.com/cclabsnz/sf-audit-plugin/releases/tag/v1.9.0) — 2026-09-07
 
 Two compliance catalogs, three attack chains, and a restructured documentation set — but

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ check id.
 | `--format` / `-f` | `html` | `html`, `md`, `json`, `executive` — comma-separated |
 | `--fail-on` | (none) | Exit 1 if any finding is at or above `CRITICAL`/`HIGH`/`MEDIUM`/`LOW`. For CI |
 | `--fail-on-inconclusive` | `false` | Exit 3 if any check could not gather evidence. For CI |
+| `--digest` | `false` | Compact result for programmatic callers — no passing checks, no prose, capped lists |
 | `--checks` | *(all)* | Run only these check ids |
 | `--frameworks` | `universal` | Compliance matrix scope for the executive report |
 
@@ -65,8 +66,14 @@ sf audit security --target-org myOrg --fail-on HIGH --fail-on-inconclusive
 # Branded, client-ready PDF-able report
 sf audit security --target-org myOrg --format executive --prepared-for "Acme Health"
 
+# What can this audit user actually establish? Ask before spending a run
+sf audit preflight --target-org myOrg
+
 # Machine-readable: result on stdout, progress logging suppressed
 sf audit security --target-org myOrg --json
+
+# Compact result for an agent or script
+sf audit security --target-org myOrg --json --digest
 ```
 
 ### Exit codes
@@ -196,7 +203,7 @@ Grade bands, the full config shape and worked examples: **[docs/SCORING.md](docs
 
 ## Other commands
 
-Beyond the audit itself, the plugin ships four commands. Each is documented in
+Beyond the audit itself, the plugin ships five commands. Each is documented in
 **[docs/COMMANDS.md](docs/COMMANDS.md)**.
 
 | Command | What it does |
@@ -204,6 +211,7 @@ Beyond the audit itself, the plugin ships four commands. Each is documented in
 | `sf audit history` / `sf audit diff` | Every run auto-archives to `~/.sf/audit-history/{orgId}`. Show posture drift across runs as a table plus an HTML timeline, or diff any two report JSONs |
 | `sf audit events pull` | Capture the org's **free** daily `EventLogFile` logs to local disk before the ~1-day retention window drops them — no Event Monitoring / Shield add-on needed. Idempotent, safe to cron |
 | `sf audit timeline` | Reconstruct one actor's activity across every captured event type, entirely offline. Refuses to expand a shared identity or join on a blank field, and always reports capture coverage first |
+| `sf audit preflight` | Read the running user's effective permissions in one query and report which checks will produce a verdict and which will return inconclusive — **before** an audit is run |
 | `sf audit apps` | Read the `RestApi` event log to compare what each connected app actually *uses* against what its run-as user is *granted*, and emit a suggested least-privilege permission set |
 
 To triage captured logs for abuse patterns, pair `events pull` with the companion CLI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cclabsnz/sf-audit",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Read-only Salesforce security audit for the sf CLI: 88 checks, attack-chain correlation, A-F risk grading, and compliance mapping to OWASP, SOC 2, ISO 27001, NZISM and more.",
   "keywords": [
     "salesforce",

--- a/src/commands/audit/preflight.ts
+++ b/src/commands/audit/preflight.ts
@@ -1,0 +1,65 @@
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { CHECKS } from '../../checks/registry.js';
+import { buildPreflight, type PreflightResult } from '../../preflight/permissionMap.js';
+import { readEffectivePermissions } from '../../preflight/readPermissions.js';
+import { buildApiClients } from '../../lib/wire.js';
+
+export default class AuditPreflightCommand extends SfCommand<PreflightResult> {
+  public static summary = 'Report what this audit user will and will not be able to establish';
+  public static description =
+    "Reads the running user's effective permissions in a single query and reports which checks will " +
+    'produce a verdict and which will return inconclusive, before an audit is run. The audit itself can ' +
+    'only report a permission gap after it has already come back blind; this answers the same question ' +
+    'up front, while it is still cheap to fix. Read-only, and opens no more than one query.';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --target-org myOrg',
+    '<%= config.bin %> <%= command.id %> --target-org myOrg --json',
+  ];
+
+  public static flags = {
+    'target-org': Flags.requiredOrg(),
+  };
+
+  public async run(): Promise<PreflightResult> {
+    const { flags } = await this.parse(AuditPreflightCommand);
+    const conn = flags['target-org'].getConnection();
+    const { soql } = buildApiClients(conn);
+
+    const granted = await readEffectivePermissions(soql);
+    const preflight = buildPreflight(granted, CHECKS);
+
+    this.printPreflight(preflight);
+    return preflight;
+  }
+
+  private printPreflight(p: PreflightResult): void {
+    this.log('');
+    if (p.missing.length === 0) {
+      this.log(`  All ${CHECKS.length} checks can gather evidence. Nothing to grant.`);
+      this.log('');
+      return;
+    }
+
+    this.log(`  ${p.willRun} of ${CHECKS.length} checks can gather evidence.`);
+    if (p.willBeInconclusive.length > 0) {
+      this.log(`  ${p.willBeInconclusive.length} will return inconclusive as things stand.`);
+    }
+    this.log('');
+    this.log('  Missing permissions');
+    this.log('  ───────────────────');
+    for (const m of p.missing) {
+      this.log(`  ${m.blocking ? '[blocking] ' : ''}${m.label} (${m.permission})`);
+      this.log(`    ${m.impact}`);
+      if (m.affectedChecks.length > 0) {
+        this.log(`    Affects ${m.affectedChecks.length} check${m.affectedChecks.length !== 1 ? 's' : ''}: ${m.affectedChecks.join(', ')}`);
+      }
+      this.log('');
+    }
+
+    if (!p.canRun) {
+      this.log('  The audit cannot run at all until the blocking permission is granted.');
+      this.log('');
+    }
+  }
+}

--- a/src/commands/audit/security.ts
+++ b/src/commands/audit/security.ts
@@ -16,6 +16,7 @@ import { buildAuditContext, resolveOrgInfo } from '../../lib/wire.js';
 import { loadScoringConfig } from '../../findings/loadScoringConfig.js';
 import { HistoryStore } from '../../history/HistoryStore.js';
 import { EXIT_FINDINGS, EXIT_INCONCLUSIVE, resolveExitCode, violationsFor } from '../../findings/exitCode.js';
+import { buildDigest, type AuditDigest } from '../../findings/digest.js';
 
 const RENDERERS: Record<string, AuditRenderer> = {
   html: new HtmlRenderer(),
@@ -23,7 +24,7 @@ const RENDERERS: Record<string, AuditRenderer> = {
   json: new JsonRenderer(),
 };
 
-export default class SecurityAuditCommand extends SfCommand<AuditResult> {
+export default class SecurityAuditCommand extends SfCommand<AuditResult | AuditDigest> {
   public static summary = 'Run a comprehensive security audit against a Salesforce org';
   public static description =
     'Runs all security checks against the target org and writes a report file.';
@@ -48,6 +49,10 @@ export default class SecurityAuditCommand extends SfCommand<AuditResult> {
     'fail-on': Flags.string({
       summary: 'Exit with code 1 if any finding is at or above this severity.',
       options: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'],
+    }),
+    digest: Flags.boolean({
+      summary: 'Return a compact, token-cheap result: no passing checks, no detail prose, capped affected lists.',
+      default: false,
     }),
     'fail-on-inconclusive': Flags.boolean({
       summary: 'Exit with code 3 if any check could not gather evidence. Off by default.',
@@ -83,7 +88,7 @@ export default class SecurityAuditCommand extends SfCommand<AuditResult> {
     }),
   };
 
-  public async run(): Promise<AuditResult> {
+  public async run(): Promise<AuditResult | AuditDigest> {
     const { flags } = await this.parse(SecurityAuditCommand);
 
     // Validate the selection and output formats up front, so a typo fails fast with
@@ -135,9 +140,11 @@ export default class SecurityAuditCommand extends SfCommand<AuditResult> {
     this.log('');
     this.log('  Deep dives: https://softwareinsights.dev   ·   Remediation help: https://cloudcounsel.co.nz');
 
+    // Exit code is resolved from the full result: the digest drops passing checks,
+    // which the threshold logic must still be able to see and discount.
     this.applyExitCode(result, flags['fail-on'] as RiskLevel | undefined, flags['fail-on-inconclusive']);
 
-    return result;
+    return flags.digest ? buildDigest(result) : result;
   }
 
   /** Resolve --checks to the checks to run, erroring on any unknown ID. */

--- a/src/findings/digest.ts
+++ b/src/findings/digest.ts
@@ -1,0 +1,100 @@
+import type { RiskLevel } from '@cclabsnz/sf-core';
+import type { AttackChain } from '../chains/AttackChain.js';
+import type { AuditResult } from './AuditResult.js';
+import type { Finding } from './Finding.js';
+
+/** How many affected-item labels to keep before falling back to a bare count. */
+const SAMPLE_LIMIT = 3;
+
+export interface DigestFinding {
+  checkId?: string;
+  riskLevel: RiskLevel;
+  title: string;
+  remediation: string;
+  complianceTags?: string[];
+  /** Total affected items. Present only when the finding named any. */
+  affectedCount?: number;
+  /** First few affected labels, for orientation. Never the whole list. */
+  affectedSample?: string[];
+}
+
+export interface DigestInconclusive {
+  checkId?: string;
+  title: string;
+}
+
+export interface DigestCounts {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  info: number;
+  passed: number;
+  inconclusive: number;
+}
+
+export interface AuditDigest {
+  orgId: string;
+  orgName: string;
+  isSandbox: boolean;
+  generatedAt: Date;
+  healthScore: number;
+  grade: AuditResult['grade'];
+  counts: DigestCounts;
+  findings: DigestFinding[];
+  inconclusive: DigestInconclusive[];
+  attackChains: AttackChain[];
+}
+
+const isActive = (f: Finding): boolean => f.passed !== true && f.inconclusive !== true;
+
+function toDigestFinding(f: Finding): DigestFinding {
+  const out: DigestFinding = {
+    checkId: f.checkId,
+    riskLevel: f.riskLevel,
+    title: f.title,
+    remediation: f.remediation,
+  };
+  if (f.complianceTags !== undefined) out.complianceTags = f.complianceTags;
+  if (f.affectedItems !== undefined && f.affectedItems.length > 0) {
+    out.affectedCount = f.affectedItems.length;
+    out.affectedSample = f.affectedItems.slice(0, SAMPLE_LIMIT).map((i) => i.label);
+  }
+  return out;
+}
+
+function countBy(findings: Finding[]): DigestCounts {
+  const counts: DigestCounts = { critical: 0, high: 0, medium: 0, low: 0, info: 0, passed: 0, inconclusive: 0 };
+  for (const f of findings) {
+    if (f.passed === true) counts.passed += 1;
+    else if (f.inconclusive === true) counts.inconclusive += 1;
+    else counts[f.riskLevel.toLowerCase() as Lowercase<RiskLevel>] += 1;
+  }
+  return counts;
+}
+
+/**
+ * A token-cheap view of an audit, for callers that reason over the result rather
+ * than read it.
+ *
+ * Passing checks are counted but not listed, `detail` prose is dropped in favour of
+ * `remediation`, and affected-item lists — which are unbounded and dominate a large
+ * org's report — collapse to a count plus a short sample. Attack chains survive
+ * intact: there are few of them and they carry the analysis.
+ */
+export function buildDigest(result: AuditResult): AuditDigest {
+  return {
+    orgId: result.orgId,
+    orgName: result.orgName,
+    isSandbox: result.isSandbox,
+    generatedAt: result.generatedAt,
+    healthScore: result.healthScore,
+    grade: result.grade,
+    counts: countBy(result.findings),
+    findings: result.findings.filter(isActive).map(toDigestFinding),
+    inconclusive: result.findings
+      .filter((f) => f.inconclusive === true)
+      .map((f) => ({ checkId: f.checkId, title: f.title })),
+    attackChains: result.attackChains ?? [],
+  };
+}

--- a/src/preflight/permissionMap.ts
+++ b/src/preflight/permissionMap.ts
@@ -1,0 +1,140 @@
+import type { AuditCache } from '@cclabsnz/sf-core';
+import type { SecurityCheck } from '../checks/SecurityCheck.js';
+import { CHECKS } from '../checks/registry.js';
+
+export type AuditPermission =
+  | 'ApiEnabled'
+  | 'ViewSetup'
+  | 'ViewAllUsers'
+  | 'ViewHealthCheckScreen'
+  | 'AuthorApex'
+  | 'ViewEventLogFiles';
+
+export interface PermissionSpec {
+  /** Field on UserPermissionAccess carrying the effective grant. */
+  readonly field: string;
+  readonly label: string;
+  /** What the audit loses without it. */
+  readonly impact: string;
+  /**
+   * Cache keys whose producers and consumers need this permission. The affected
+   * check list is derived from the registry via these keys rather than hand-written,
+   * so a check added later is covered without touching this file.
+   *
+   * Empty for permissions too broad to attribute to specific checks.
+   */
+  readonly cacheKeys: ReadonlyArray<keyof AuditCache>;
+  /** The audit cannot run at all without this. */
+  readonly blocking?: boolean;
+}
+
+export const AUDIT_PERMISSIONS: Readonly<Record<AuditPermission, PermissionSpec>> = {
+  ApiEnabled: {
+    field: 'PermissionsApiEnabled',
+    label: 'API Enabled',
+    impact: 'All access is via SOQL/Tooling/REST. Without it the audit cannot run at all.',
+    cacheKeys: [],
+    blocking: true,
+  },
+  ViewSetup: {
+    field: 'PermissionsViewSetup',
+    label: 'View Setup and Configuration',
+    impact:
+      'Reads the bulk of the surface — connected apps, remote sites, CSP, named credentials, auth config, ' +
+      'Experience sites, and Tooling metadata. Most setup and configuration checks return inconclusive without it.',
+    cacheKeys: [],
+  },
+  ViewAllUsers: {
+    field: 'PermissionsViewAllUsers',
+    label: 'View All Users',
+    impact:
+      'Enumerates every User, PermissionSetAssignment and TwoFactorInfo org-wide. Without it the user, ' +
+      'admin and MFA checks under-count and miss accounts outside the role hierarchy.',
+    cacheKeys: ['mfaRegistrations', 'effectivePermissions'],
+  },
+  ViewHealthCheckScreen: {
+    field: 'PermissionsViewHealthCheck',
+    label: 'View Health Check',
+    impact: 'Reads SecurityHealthCheck and its risks. Health Check and password/session baselines are inconclusive without it.',
+    cacheKeys: ['healthCheckRisks'],
+  },
+  AuthorApex: {
+    field: 'PermissionsAuthorApex',
+    label: 'Author Apex (read-only use)',
+    impact:
+      'The only standard gate exposing ApexClass/ApexTrigger/ApexPage Body via the Tooling API. ' +
+      'Grants no ability to modify org data. The code-security checks are inconclusive without it.',
+    cacheKeys: ['apexBodies', 'vfPageBodies'],
+  },
+  ViewEventLogFiles: {
+    field: 'PermissionsViewEventLogFiles',
+    label: 'View Event Log Files',
+    impact: 'Reads EventLogFile. Whether login and API activity is monitored cannot be established without it.',
+    cacheKeys: ['eventLogSummary'],
+  },
+};
+
+export interface MissingPermission {
+  permission: AuditPermission;
+  label: string;
+  impact: string;
+  blocking: boolean;
+  affectedChecks: string[];
+}
+
+export interface PreflightResult {
+  canRun: boolean;
+  granted: AuditPermission[];
+  missing: MissingPermission[];
+  /** Checks expected to produce a verdict. */
+  willRun: number;
+  /** Checks expected to return inconclusive, deduplicated across permissions. */
+  willBeInconclusive: string[];
+}
+
+const usesKey = (check: SecurityCheck, key: keyof AuditCache): boolean =>
+  (check.dependsOnCache?.includes(key) ?? false) || (check.populatesCache?.includes(key) ?? false);
+
+/** Check ids that need `permission`, derived from the registry's declared cache wiring. */
+export function checksRequiring(permission: AuditPermission, checks: readonly SecurityCheck[] = CHECKS): string[] {
+  const { cacheKeys } = AUDIT_PERMISSIONS[permission];
+  if (cacheKeys.length === 0) return [];
+  return checks.filter((c) => cacheKeys.some((k) => usesKey(c, k))).map((c) => c.id);
+}
+
+/**
+ * What this audit user will and will not be able to establish, before spending a run.
+ *
+ * The tool can only report a permission gap after the audit has already come back
+ * blind; this answers the same question up front, when it is still cheap to fix.
+ */
+export function buildPreflight(
+  granted: Record<AuditPermission, boolean>,
+  checks: readonly SecurityCheck[] = CHECKS,
+): PreflightResult {
+  const permissions = Object.keys(AUDIT_PERMISSIONS) as AuditPermission[];
+  const missing: MissingPermission[] = [];
+  const inconclusive = new Set<string>();
+
+  for (const permission of permissions) {
+    if (granted[permission]) continue;
+    const spec = AUDIT_PERMISSIONS[permission];
+    const affectedChecks = checksRequiring(permission, checks);
+    affectedChecks.forEach((id) => inconclusive.add(id));
+    missing.push({
+      permission,
+      label: spec.label,
+      impact: spec.impact,
+      blocking: spec.blocking === true,
+      affectedChecks,
+    });
+  }
+
+  return {
+    canRun: !missing.some((m) => m.blocking),
+    granted: permissions.filter((p) => granted[p]),
+    missing,
+    willRun: checks.length - inconclusive.size,
+    willBeInconclusive: [...inconclusive],
+  };
+}

--- a/src/preflight/readPermissions.ts
+++ b/src/preflight/readPermissions.ts
@@ -1,0 +1,24 @@
+import type { SoqlClient } from '@cclabsnz/sf-core';
+import { AUDIT_PERMISSIONS, type AuditPermission } from './permissionMap.js';
+
+type PermissionRow = Record<string, boolean | undefined>;
+
+/**
+ * The running user's *effective* permissions — profile unioned with every assigned
+ * permission set — in one read.
+ *
+ * UserPermissionAccess returns exactly one row scoped to the caller, so this needs no
+ * assignment join and no aggregation. Read-only, like everything else here.
+ */
+export async function readEffectivePermissions(soql: SoqlClient): Promise<Record<AuditPermission, boolean>> {
+  const permissions = Object.keys(AUDIT_PERMISSIONS) as AuditPermission[];
+  const fields = permissions.map((p) => AUDIT_PERMISSIONS[p].field);
+  const result = await soql.query<PermissionRow>(`SELECT ${fields.join(', ')} FROM UserPermissionAccess`);
+  const row = result.records[0] ?? {};
+
+  const granted = {} as Record<AuditPermission, boolean>;
+  for (const permission of permissions) {
+    granted[permission] = row[AUDIT_PERMISSIONS[permission].field] === true;
+  }
+  return granted;
+}

--- a/test/unit/commands/json-flag.test.ts
+++ b/test/unit/commands/json-flag.test.ts
@@ -4,6 +4,7 @@ import AuditHistoryCommand from '../../../src/commands/audit/history.js';
 import AuditListCommand from '../../../src/commands/audit/list.js';
 import SecurityAuditCommand from '../../../src/commands/audit/security.js';
 import AuditTimelineCommand from '../../../src/commands/audit/timeline.js';
+import AuditPreflightCommand from '../../../src/commands/audit/preflight.js';
 import AuditEventsPullCommand from '../../../src/commands/audit/events/pull.js';
 
 /**
@@ -26,13 +27,14 @@ const COMMANDS = [
   ['audit diff', AuditDiffCommand],
   ['audit apps', AuditAppsCommand],
   ['audit timeline', AuditTimelineCommand],
+  ['audit preflight', AuditPreflightCommand],
   ['audit events pull', AuditEventsPullCommand],
 ] as const;
 
 describe('--json is available on every command', () => {
   it('covers every command the plugin ships', () => {
     // Guards against the suite passing vacuously if the list above is gutted.
-    expect(COMMANDS).toHaveLength(7);
+    expect(COMMANDS).toHaveLength(8);
   });
 
   it.each(COMMANDS)('%s enables the json flag', (_name, Command) => {

--- a/test/unit/findings/digest.test.ts
+++ b/test/unit/findings/digest.test.ts
@@ -1,0 +1,107 @@
+import type { RiskLevel } from '@cclabsnz/sf-core';
+import type { AttackChain } from '../../../src/chains/AttackChain.js';
+import type { AuditResult } from '../../../src/findings/AuditResult.js';
+import type { Finding } from '../../../src/findings/Finding.js';
+import { buildDigest } from '../../../src/findings/digest.js';
+
+const finding = (riskLevel: RiskLevel, extra: Partial<Finding> = {}): Finding => ({
+  id: `${riskLevel}-${extra.checkId ?? 'x'}`,
+  checkId: 'some-check',
+  category: 'Test',
+  riskLevel,
+  title: `${riskLevel} finding`,
+  detail: 'A long prose explanation that agents pay for and rarely need.',
+  remediation: 'Do the thing.',
+  ...extra,
+});
+
+const result = (findings: Finding[]): AuditResult => ({
+  generatedAt: new Date('2026-09-07T00:00:00Z'),
+  orgId: '00D000000000001',
+  orgName: 'Test Org',
+  orgType: 'Production',
+  isSandbox: false,
+  instance: 'APAC1',
+  instanceUrl: 'https://example.my.salesforce.com',
+  findings,
+  metrics: { totalUsers: 240 } as unknown as AuditResult['metrics'],
+  healthScore: 61,
+  grade: 'D',
+  attackChains: [],
+});
+
+describe('buildDigest', () => {
+  it('drops passed findings from the finding list', () => {
+    const d = buildDigest(result([finding('INFO', { passed: true }), finding('HIGH')]));
+    expect(d.findings).toHaveLength(1);
+    expect(d.findings[0].riskLevel).toBe('HIGH');
+  });
+
+  it('counts passed findings even though it drops them', () => {
+    const d = buildDigest(result([finding('INFO', { passed: true }), finding('HIGH')]));
+    expect(d.counts.passed).toBe(1);
+    expect(d.counts.high).toBe(1);
+  });
+
+  it('drops the detail prose from active findings', () => {
+    const d = buildDigest(result([finding('HIGH')]));
+    expect(JSON.stringify(d)).not.toContain('agents pay for');
+  });
+
+  it('keeps remediation on active findings', () => {
+    const d = buildDigest(result([finding('HIGH')]));
+    expect(d.findings[0].remediation).toBe('Do the thing.');
+  });
+
+  it('replaces a long affectedItems list with a count and a capped sample', () => {
+    const affectedItems = Array.from({ length: 40 }, (_, i) => ({ label: `user${i}` }));
+    const d = buildDigest(result([finding('HIGH', { affectedItems })]));
+    expect(d.findings[0].affectedCount).toBe(40);
+    expect(d.findings[0].affectedSample).toEqual(['user0', 'user1', 'user2']);
+  });
+
+  it('omits the affected fields entirely when a finding has none', () => {
+    const d = buildDigest(result([finding('HIGH')]));
+    expect(d.findings[0].affectedCount).toBeUndefined();
+    expect(d.findings[0].affectedSample).toBeUndefined();
+  });
+
+  it('reduces inconclusive findings to checkId and title, in their own list', () => {
+    const d = buildDigest(result([finding('INFO', { inconclusive: true, checkId: 'code-security' })]));
+    expect(d.findings).toHaveLength(0);
+    expect(d.inconclusive).toEqual([{ checkId: 'code-security', title: 'INFO finding' }]);
+    expect(d.counts.inconclusive).toBe(1);
+  });
+
+  it('keeps attack chains in full — they are the analytical payload', () => {
+    const chains: AttackChain[] = [{
+      id: 'c1',
+      title: 'guest to bulk data',
+      severity: 'CRITICAL',
+      confidence: 'named',
+      narrative: 'A long narrative that must survive the digest intact.',
+      remediation: 'Break any one step.',
+      steps: [{ findingId: 'f1', capability: 'unauthenticated-entry' as AttackChain['steps'][number]['capability'] }],
+    }];
+    const base = result([]);
+    const d = buildDigest({ ...base, attackChains: chains });
+    expect(d.attackChains).toEqual(chains);
+  });
+
+  it('drops org metrics', () => {
+    const d = buildDigest(result([])) as unknown as Record<string, unknown>;
+    expect(d.metrics).toBeUndefined();
+  });
+
+  it('is materially smaller than the full result', () => {
+    const many = [
+      ...Array.from({ length: 12 }, () => finding('INFO', { passed: true })),
+      ...Array.from({ length: 8 }, () => finding('HIGH', {
+        affectedItems: Array.from({ length: 30 }, (_, i) => ({ label: `item${i}` })),
+      })),
+    ];
+    const full = result(many);
+    const ratio = JSON.stringify(full).length / JSON.stringify(buildDigest(full)).length;
+    expect(ratio).toBeGreaterThan(5);
+  });
+});

--- a/test/unit/preflight/permissionMap.test.ts
+++ b/test/unit/preflight/permissionMap.test.ts
@@ -1,0 +1,84 @@
+import { CHECKS } from '../../../src/checks/registry.js';
+import {
+  AUDIT_PERMISSIONS,
+  buildPreflight,
+  checksRequiring,
+  type AuditPermission,
+} from '../../../src/preflight/permissionMap.js';
+
+const ALL_GRANTED: Record<AuditPermission, boolean> = {
+  ApiEnabled: true,
+  ViewSetup: true,
+  ViewAllUsers: true,
+  ViewHealthCheckScreen: true,
+  AuthorApex: true,
+  ViewEventLogFiles: true,
+};
+
+describe('checksRequiring', () => {
+  it('derives Apex-body checks from the registry, not a hand-written list', () => {
+    const ids = checksRequiring('AuthorApex');
+    expect(ids).toContain('apex-sharing');
+    expect(ids).toContain('code-security');
+  });
+
+  it('derives the Health Check dependants', () => {
+    expect(checksRequiring('ViewHealthCheckScreen')).toEqual(
+      expect.arrayContaining(['health-check', 'session-hardening', 'password-session-policy']),
+    );
+  });
+
+  it('derives the Event Monitoring dependants', () => {
+    expect(checksRequiring('ViewEventLogFiles')).toEqual(
+      expect.arrayContaining(['event-monitoring', 'siem-integration']),
+    );
+  });
+
+  it('only ever names checks that exist in the registry', () => {
+    const known = new Set(CHECKS.map((c) => c.id));
+    for (const perm of Object.keys(AUDIT_PERMISSIONS) as AuditPermission[]) {
+      for (const id of checksRequiring(perm)) {
+        expect(known).toContain(id);
+      }
+    }
+  });
+
+  it('returns no per-check list for broad permissions', () => {
+    // ViewSetup underpins most of the surface; enumerating it would imply a precision
+    // the mapping does not have.
+    expect(checksRequiring('ViewSetup')).toEqual([]);
+  });
+});
+
+describe('buildPreflight', () => {
+  it('reports a fully permissioned user as ready with nothing missing', () => {
+    const p = buildPreflight(ALL_GRANTED);
+    expect(p.canRun).toBe(true);
+    expect(p.missing).toHaveLength(0);
+    expect(p.willBeInconclusive).toHaveLength(0);
+  });
+
+  it('reports the audit as unable to run without ApiEnabled', () => {
+    const p = buildPreflight({ ...ALL_GRANTED, ApiEnabled: false });
+    expect(p.canRun).toBe(false);
+    expect(p.missing.find((m) => m.permission === 'ApiEnabled')?.blocking).toBe(true);
+  });
+
+  it('names the checks that will come back inconclusive', () => {
+    const p = buildPreflight({ ...ALL_GRANTED, AuthorApex: false });
+    expect(p.canRun).toBe(true);
+    expect(p.willBeInconclusive).toContain('apex-sharing');
+    expect(p.missing.map((m) => m.permission)).toEqual(['AuthorApex']);
+  });
+
+  it('does not double-count a check blocked by two missing permissions', () => {
+    const p = buildPreflight({ ...ALL_GRANTED, AuthorApex: false, ViewHealthCheckScreen: false });
+    expect(new Set(p.willBeInconclusive).size).toBe(p.willBeInconclusive.length);
+  });
+
+  it('carries the remediation for each missing permission', () => {
+    const p = buildPreflight({ ...ALL_GRANTED, ViewEventLogFiles: false });
+    expect(p.missing[0].impact).toMatch(/.+/);
+    expect(p.missing[0].label).toMatch(/.+/);
+  });
+});

--- a/test/unit/preflight/readPermissions.test.ts
+++ b/test/unit/preflight/readPermissions.test.ts
@@ -1,0 +1,42 @@
+import type { SoqlClient } from '@cclabsnz/sf-core';
+import { readEffectivePermissions } from '../../../src/preflight/readPermissions.js';
+
+const soqlReturning = (records: Array<Record<string, boolean>>): { client: SoqlClient; queries: string[] } => {
+  const queries: string[] = [];
+  const client = {
+    query: async <T>(soql: string) => {
+      queries.push(soql);
+      return { totalSize: records.length, done: true, records: records as T[] };
+    },
+    queryAll: async <T>() => records as T[],
+  } as SoqlClient;
+  return { client, queries };
+};
+
+describe('readEffectivePermissions', () => {
+  it('reads the caller\'s own effective permissions in a single query', async () => {
+    const { client, queries } = soqlReturning([{ PermissionsApiEnabled: true }]);
+    await readEffectivePermissions(client);
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).toContain('FROM UserPermissionAccess');
+  });
+
+  it('maps present grants to true', async () => {
+    const { client } = soqlReturning([{ PermissionsApiEnabled: true, PermissionsAuthorApex: true }]);
+    const granted = await readEffectivePermissions(client);
+    expect(granted.ApiEnabled).toBe(true);
+    expect(granted.AuthorApex).toBe(true);
+  });
+
+  it('treats an absent field as not granted rather than undefined', async () => {
+    const { client } = soqlReturning([{ PermissionsApiEnabled: true }]);
+    const granted = await readEffectivePermissions(client);
+    expect(granted.AuthorApex).toBe(false);
+  });
+
+  it('treats an empty result as nothing granted rather than throwing', async () => {
+    const { client } = soqlReturning([]);
+    const granted = await readEffectivePermissions(client);
+    expect(Object.values(granted).every((v) => v === false)).toBe(true);
+  });
+});


### PR DESCRIPTION
Two gaps for anything driving this plugin as a tool rather than reading its reports.

## `sf audit preflight`

Answers *"what will this audit user actually be able to establish"* before a run is spent.

The audit can only report a permission gap **after** it has already come back blind — by
then the run is gone and the answer is a re-run. Preflight reads the caller's effective
permissions from `UserPermissionAccess` in a single query, names the checks that will
return inconclusive, and gives the grants that would fix them.

**The affected-check lists are derived, not hand-maintained.** They come from the
registry's declared cache wiring: `apexBodies`/`vfPageBodies` → `AuthorApex`,
`healthCheckRisks` → `ViewHealthCheckScreen`, `eventLogSummary` → `ViewEventLogFiles`. A
check added later is covered without editing the map, and a test pins every id in the map
against `CHECKS` so it cannot rot.

Permissions too broad to attribute to specific checks (`ApiEnabled`, `ViewSetup`) report
their impact without claiming a precision the mapping does not have.

## `--digest`

A compact result for programmatic callers:

- passing checks **counted but not listed**
- `detail` prose dropped in favour of `remediation`
- `affectedItems` — unbounded, and the bulk of a large org's report — collapsed to a count
  plus a three-item sample
- attack chains kept **intact**; there are few and they carry the analysis

On a representative 405-finding report (120 active / 265 passed / 20 inconclusive):

| | size |
|---|---:|
| full result | 617.0 KB |
| `--digest` | 41.3 KB |
| | **14.9x smaller** |

Composes with `--json`, so a caller gets one command and compact stdout.

The exit code is still resolved from the **full** result, since the digest drops the
passing checks the threshold logic needs to see and discount.

## Verification

- `pnpm run build` — clean
- `pnpm test` — **1157 passed / 120 suites** (25 new)
- `pnpm audit --prod --audit-level high` — no known vulnerabilities
- `pnpm run lint` — clean