### PR TITLE
chore(ci): exempt bot authors from DCO, pin browserslist over two advisories

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,6 +5,8 @@ name: DCO
 # contributor has the right to submit the work under the project's licence.
 #
 # Checked here rather than trusted, because a missing sign-off is invisible at review time.
+#
+# Bot authors (`*[bot]`) are exempt: see the inline note in the check step.
 on:
   pull_request:
     branches: [main]
@@ -33,7 +35,18 @@ jobs:
           # Skip merge commits: they have no authored content to certify.
           for sha in $(git rev-list --no-merges "$BASE".."$HEAD"); do
             author="$(git log -1 --pretty='%an <%ae>' "$sha")"
+            name="$(git log -1 --pretty='%an' "$sha")"
             subject="$(git log -1 --pretty='%s' "$sha")"
+            # Automated dependency PRs have no human authorship to certify. The bot is not
+            # asserting a right to submit anything; the maintainer merging it is. Without
+            # this exemption every Dependabot PR is permanently unmergeable, which is worse
+            # for security than the gate is good — bumps stop landing and the tree rots.
+            case "$name" in
+              *'[bot]')
+                echo "skip  ${sha:0:8}  $subject  (bot author: $name)"
+                continue
+                ;;
+            esac
             if git log -1 --pretty='%B' "$sha" | grep -qiF "Signed-off-by: $author"; then
               echo "ok    ${sha:0:8}  $subject"
             else

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
       "js-yaml@3": "^3.15.1",
       "handlebars": "^4.7.9",
       "brace-expansion": "^5.0.9",
-      "fast-uri@3": "^3.1.6"
+      "fast-uri@3": "^3.1.6",
+      "browserslist": "^4.28.7"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  form-data: ^4.0.6
-  js-yaml@3: ^3.15.1
-  handlebars: ^4.7.9
   brace-expansion: ^5.0.9
+  browserslist: ^4.28.7
   fast-uri@3: ^3.1.6
+  form-data: ^4.0.6
+  handlebars: ^4.7.9
+  js-yaml@3: ^3.15.1
 
 importers:
 
@@ -1144,8 +1145,8 @@ packages:
     resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
     engines: {node: '>=6.0.0'}
 
-  baseline-browser-mapping@2.10.34:
-    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
+  baseline-browser-mapping@2.11.21:
+    resolution: {integrity: sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1153,8 +1154,8 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.9:
+    resolution: {integrity: sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1189,8 +1190,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001797:
-    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -1368,8 +1369,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.368:
-    resolution: {integrity: sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==}
+  electron-to-chromium@1.5.422:
+    resolution: {integrity: sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -2036,8 +2037,8 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.47:
-    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
 
   normalize-path@3.0.0:
@@ -2496,11 +2497,11 @@ packages:
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: ^4.28.7
 
   upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
@@ -2663,7 +2664,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -3711,19 +3712,19 @@ snapshots:
 
   base64url@3.0.1: {}
 
-  baseline-browser-mapping@2.10.34: {}
+  baseline-browser-mapping@2.11.21: {}
 
   brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.2:
+  browserslist@4.28.9:
     dependencies:
-      baseline-browser-mapping: 2.10.34
-      caniuse-lite: 1.0.30001797
-      electron-to-chromium: 1.5.368
-      node-releases: 2.0.47
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.21
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.422
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.9)
 
   bser@2.1.1:
     dependencies:
@@ -3754,7 +3755,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001797: {}
+  caniuse-lite@1.0.30001810: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -3916,7 +3917,7 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.368: {}
+  electron-to-chromium@1.5.422: {}
 
   emittery@0.13.1: {}
 
@@ -4751,7 +4752,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.47: {}
+  node-releases@2.0.54: {}
 
   normalize-path@3.0.0: {}
 
@@ -5257,9 +5258,9 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.9):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       escalade: 3.2.0
       picocolors: 1.1.1
 


### PR DESCRIPTION
## The DCO gate is blocking all dependency maintenance

Five Dependabot PRs (#90, #91, #92, #94, #95) have been open since 2026-09-02 and **none of
them can ever merge.** The DCO check requires every non-merge commit to carry a
`Signed-off-by` trailer matching its author — and Dependabot does not sign off its commits.

The gate was quietly turning automated dependency maintenance into a permanent backlog. That
is a net loss for the thing DCO exists to protect: bumps stop landing and the tree rots.

Bot authors (`*[bot]`) are now skipped. DCO certifies that a **human contributor** has the
right to submit the work; a bot bumping a pinned action SHA asserts nothing, and the
maintainer merging it is the one making the assertion. Human commits are unchanged — trailer
still required, still matched against the author.

## browserslist — two HIGH advisories

| Advisory | CVE | Issue |
|---|---|---|
| GHSA-73wf-gq98-2v4g | CVE-2026-73088 | Uncaught crash / prototype write via untrusted `browserslist-stats.json` in `normalizeStats` |
| GHSA-c83g-rgw3-j3cx | CVE-2026-73089 | Unbounded memory growth, no cache eviction, eventual OOM |

Pinned to `^4.28.7` via the existing `pnpm.overrides` block, consistent with how `fast-uri`,
`form-data`, `handlebars`, `js-yaml` and `brace-expansion` are already handled. Resolves to
4.28.9.

**Neither ships.** Both reach the tree development-only and transitively via
`jest > babel-jest > @babel/core > helper-compilation-targets`; the published tarball is
`lib`, `messages`, `config`. That is why `pnpm audit --prod` stayed green while the alerts
stood — worth knowing, since it means the production gate cannot see this class of alert.

The lockfile diff is confined to browserslist and its own data tables (`caniuse-lite`,
`electron-to-chromium`, `node-releases`, `baseline-browser-mapping`, `update-browserslist-db`).
Nothing else moved.

## After this merges

The five Dependabot PRs need a rebase to pick up the workflow change, then they should go
green and can be merged.

## Verification

- `pnpm test` — 1171 passed / 121 suites
- `pnpm audit --audit-level high` (dev included, not just `--prod`) — no known vulnerabilities
- `pnpm run build` and `lint` — clean
