### PR TITLE
chore(ci): bump codeql-action to 4.37.9 in one change, not three

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,7 +36,7 @@ jobs:
             --sarif --output semgrep.sarif || true
 
       - name: Upload findings to code scanning
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: semgrep.sarif
           category: semgrep


### PR DESCRIPTION
Supersedes #90, #94 and #95.

## Why those three could never pass

Dependabot opened the `codeql-action` bump as three separate PRs — `analyze` (#90), `init`
(#94), `upload-sarif` (#95) — and **none of them can go green on its own.** CodeQL requires
`init` and `analyze` to run the same version:

```
##[error] Loaded a configuration file for version '4.37.7', but running version '4.37.9'
```

#90 bumped `analyze` against a 4.37.7 `init` and failed. #94 bumped `init` against a 4.37.7
`analyze` and failed identically. Each PR is individually correct and jointly impossible.

Splitting by action path is the right default for independent actions and the wrong one for
a family that version-locks together.

## This change

All four references move together, still SHA-pinned with the version in the trailing comment:

| Workflow | Action |
|---|---|
| `codeql.yml` | `codeql-action/init` |
| `codeql.yml` | `codeql-action/analyze` |
| `scorecard.yml` | `codeql-action/upload-sarif` |
| `semgrep.yml` | `codeql-action/upload-sarif` |

`ff2f1c62…` (v4.37.7) → `cdf488f5…` (v4.37.9). No `4.37.7` references remain.
