### PR TITLE
feat(soap-login-api-auth): register the unwired check, and cover three more with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 A Salesforce CLI (`sf`) plugin that runs a complete, **read-only** security audit against any Salesforce org, risk-scores it with an A–F grade, and turns the result into a report your security team (or your client's) can act on.
 
-- **91 read-only checks** across identity, access, data, code, integrations, monitoring, and Agentforce / GenAI
+- **92 read-only checks** across identity, access, data, code, integrations, monitoring, and Agentforce / GenAI
 - **Attack-chain correlation:** links individual findings into named, multi-step attack scenarios — eleven modelled chains, plus an emergent pass for combinations nobody has named yet (see [Attack chains](#attack-chains))
 - **Compliance mapping:** every finding mapped to **source-verified** controls across 10 frameworks (OWASP, OWASP LLM Top 10, SOC 2, ISO/IEC 27001:2022, Security Benchmark for Salesforce, NZ Privacy Act, HISO 10029, NZISM, HIPAA Security Rule, GDPR)
 - **Outputs:** a technical `html` / `md` / `json` report, or a branded, client-ready **executive report** (print-to-PDF) with priorities, remediation roadmap, and a compliance coverage matrix
@@ -44,7 +44,7 @@ guarantees here are checkable rather than asserted — see [Trust & verification
 sf audit security --target-org <orgAlias>
 ```
 
-Runs all 91 checks and writes an HTML report to the current directory. `sf audit list` prints every
+Runs all 92 checks and writes an HTML report to the current directory. `sf audit list` prints every
 check id.
 
 | Flag | Default | |
@@ -94,13 +94,13 @@ All twelve flags, more examples, and what the executive report contains:
 
 ## What It Checks
 
-**91 read-only checks** across ten domains. Every finding is risk-rated CRITICAL → INFO, mapped to
+**92 read-only checks** across ten domains. Every finding is risk-rated CRITICAL → INFO, mapped to
 compliance controls, and correlated into [attack chains](#attack-chains).
 
 | Domain | Checks |
 |--------|-------:|
 | Identity & Authentication | 13 |
-| Users, Permissions & Privilege | 12 |
+| Users, Permissions & Privilege | 13 |
 | Data Access & Sharing | 11 |
 | Guest & External-Facing Access | 12 |
 | Integrations, Connected Apps & Deployments | 11 |

--- a/docs/ASSURANCE-CASE.md
+++ b/docs/ASSURANCE-CASE.md
@@ -115,7 +115,7 @@ data exists the claim is scoped rather than dropped — `public-group-sharing` s
 tables it checked and which it could not, because an object may be absent by org edition rather
 than by permission.
 
-**Coverage of the argument.** 92 checks, 122 test suites, 1181 tests. Coverage is not itself an
+**Coverage of the argument.** 92 checks, 125 test suites, 1206 tests. Coverage is not itself an
 assurance argument, but an untested check is an unexamined claim, and every defect listed above was
 found by writing a test rather than by reading the code.
 
@@ -124,7 +124,7 @@ read as coverage of the codebase. `jest.config.ts` sets no `collectCoverageFrom`
 test actually imports are instrumented, and files no test reaches are absent from the denominator
 rather than counted as zero. It instruments 88 of the 171 files under `src/`, so the figure
 describes a little over half the codebase and says nothing about the rest. It is coverage of the
-tested code. 36 of the 92 checks still have no
+tested code. 33 of the 92 checks still have no
 unit test file, which is the figure that matters here and is tracked in
 [ROADMAP.md](ROADMAP.md).
 

--- a/docs/ASSURANCE-CASE.md
+++ b/docs/ASSURANCE-CASE.md
@@ -115,7 +115,7 @@ data exists the claim is scoped rather than dropped — `public-group-sharing` s
 tables it checked and which it could not, because an object may be absent by org edition rather
 than by permission.
 
-**Coverage of the argument.** 91 checks, 121 test suites, 1171 tests. Coverage is not itself an
+**Coverage of the argument.** 92 checks, 122 test suites, 1181 tests. Coverage is not itself an
 assurance argument, but an untested check is an unexamined claim, and every defect listed above was
 found by writing a test rather than by reading the code.
 
@@ -124,7 +124,7 @@ read as coverage of the codebase. `jest.config.ts` sets no `collectCoverageFrom`
 test actually imports are instrumented, and files no test reaches are absent from the denominator
 rather than counted as zero. It instruments 88 of the 171 files under `src/`, so the figure
 describes a little over half the codebase and says nothing about the rest. It is coverage of the
-tested code. 36 of the 91 checks still have no
+tested code. 36 of the 92 checks still have no
 unit test file, which is the figure that matters here and is tracked in
 [ROADMAP.md](ROADMAP.md).
 

--- a/docs/CHECKS.md
+++ b/docs/CHECKS.md
@@ -1,6 +1,6 @@
 # What it checks
 
-The audit runs **91 read-only checks**. The [README](../README.md#what-it-checks) summarises them by domain; this is the full inventory. Every finding is risk-rated (CRITICAL → INFO) and mapped to controls across the compliance frameworks (see [Compliance frameworks](#compliance-frameworks)). The checks are grouped into ten domains below.
+The audit runs **92 read-only checks**. The [README](../README.md#what-it-checks) summarises them by domain; this is the full inventory. Every finding is risk-rated (CRITICAL → INFO) and mapped to controls across the compliance frameworks (see [Compliance frameworks](#compliance-frameworks)). The checks are grouped into ten domains below.
 
 ## Org Health & Configuration
 | Check | What it looks for |
@@ -35,6 +35,7 @@ The audit runs **91 read-only checks**. The [README](../README.md#what-it-checks
 | Permissions | Unassigned permission sets and high profile counts that widen the attack surface |
 | Standard Profile Usage | Active users assigned to out-of-the-box standard profiles |
 | Use Any API Client | Users with the permission that bypasses API Access Control |
+| SOAP login() Use Any API Auth | Accounts authenticating via SOAP `login()` without the permission Winter '27 requires, and holders that no longer need it (a different permission from Use Any API Client) |
 | Privilege Escalation Permissions | Users holding lateral-movement / persistence permission clusters |
 | Privileged Access & Shadow Admins | Effective high-risk permissions per user (profile + permission sets + groups); admin-equivalent users not on the System Administrator profile |
 | Separation of Duties | Toxic permission combinations a single user holds (e.g. Manage Users + Assign Permission Sets, Author Apex + Modify All Data) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ Anything already shipped lives in [CHANGELOG.md](../CHANGELOG.md).
 
 ## Near term
 
-**Finish the test coverage sweep.** 36 of the 91 checks still have no unit test file. The
+**Finish the test coverage sweep.** 36 of the 92 checks still have no unit test file. The
 statement-coverage figure (80%) is now adequate, but that is a side effect rather than the point:
 every check corrected for reporting a conclusion it had not established was found by writing a test,
 never by reading the code. The remaining 36 are unexamined claims.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ Anything already shipped lives in [CHANGELOG.md](../CHANGELOG.md).
 
 ## Near term
 
-**Finish the test coverage sweep.** 36 of the 92 checks still have no unit test file. The
+**Finish the test coverage sweep.** 33 of the 92 checks still have no unit test file. The
 statement-coverage figure (80%) is now adequate, but that is a side effect rather than the point:
 every check corrected for reporting a conclusion it had not established was found by writing a test,
 never by reading the code. The remaining 36 are unexamined claims.

--- a/src/checks/registry.ts
+++ b/src/checks/registry.ts
@@ -27,6 +27,7 @@ import { StandardProfilesCheck } from './impl/StandardProfilesCheck.js';
 import { SsoEnforcementCheck } from './impl/SsoEnforcementCheck.js';
 import { MfaEnforcementCheck } from './impl/MfaEnforcementCheck.js';
 import { ApiClientPermissionCheck } from './impl/ApiClientPermissionCheck.js';
+import { SoapLoginApiAuthCheck } from './impl/SoapLoginApiAuthCheck.js';
 import { IntegrationUsersCheck } from './impl/IntegrationUsersCheck.js';
 import { IntegrationLeastPrivilegeCheck } from './impl/IntegrationLeastPrivilegeCheck.js';
 import { ContentLinksCheck } from './impl/ContentLinksCheck.js';
@@ -130,6 +131,7 @@ export const CHECKS: SecurityCheck[] = [
   new SsoEnforcementCheck(),       // SBS-AUTH-001/002
   new MfaEnforcementCheck(),       // SBS-AUTH-004 (portal users)
   new ApiClientPermissionCheck(),  // SBS-ACS-006
+  new SoapLoginApiAuthCheck(),   // Winter '27 SOAP login() readiness; distinct from Use Any API Client above
   new IntegrationUsersCheck(),     // SBS-ACS-007/008/009
   new IntegrationLeastPrivilegeCheck(),   // permissions integration accounts hold and do not use
   new ContentLinksCheck(),         // SBS-FILE-001/002/003

--- a/src/compliance/mapping.ts
+++ b/src/compliance/mapping.ts
@@ -31,6 +31,7 @@ const BASE_CHECK_CONTROL_MAP: Record<string, string[]> = {
   'sso-enforcement':         ['OWASP-A07', 'SOC2-CC6.1', 'ISO-A.8.3', 'SBS-AUTH-001', 'SBS-AUTH-002'],
   'mfa-enforcement':         ['OWASP-A07', 'SOC2-CC6.1', 'ISO-A.8.3', 'SBS-AUTH-004'],
   'api-client-permission':   ['OWASP-A01', 'SOC2-CC6.3', 'ISO-A.8.3', 'SBS-ACS-006'],
+  'soap-login-api-auth':     ['OWASP-A01', 'SOC2-CC6.1', 'ISO-A.5.18'],
   'integration-users':       ['OWASP-A01', 'SOC2-CC6.1', 'ISO-A.5.18', 'SBS-ACS-007', 'SBS-ACS-008', 'SBS-ACS-009'],
   'integration-least-privilege': ['OWASP-A01', 'SOC2-CC6.3', 'ISO-A.5.18', 'SBS-ACS-008', 'SBS-ACS-009'],
   'content-links':           ['OWASP-A01', 'SOC2-CC6.1', 'ISO-A.5.14', 'SBS-FILE-001', 'SBS-FILE-002', 'SBS-FILE-003'],
@@ -115,7 +116,7 @@ const BASE_CHECK_CONTROL_MAP: Record<string, string[]> = {
 // so the two cannot drift apart in which checks they consider part of a domain.
 const DOMAIN = {
   accessControl: ['users-and-admins', 'permissions', 'sharing-model', 'public-group-sharing', 'guest-user-access',
-                  'field-level-security', 'standard-profiles', 'api-client-permission', 'integration-users',
+                  'field-level-security', 'standard-profiles', 'api-client-permission', 'soap-login-api-auth', 'integration-users',
                   'integration-least-privilege',
                   'escalation-perms', 'report-folder-access', 'apex-crud-fls', 'apex-rest-endpoint',
                   'guest-executable-apex', 'experience-cloud-site', 'content-links', 'apex-sharing', 'flows-without-sharing',

--- a/src/findings/CheckMeta.ts
+++ b/src/findings/CheckMeta.ts
@@ -33,6 +33,7 @@ export const CHECK_META: Record<string, CheckMeta> = {
   'sso-enforcement':         { effort: 'project',  impact: 'Without enforced SSO, username/password logins bypass your identity provider’s MFA and conditional access.' },
   'mfa-enforcement':         { effort: 'quick',    impact: 'Portal/external users without MFA let a stolen password reach customer or partner data directly.' },
   'api-client-permission':   { effort: 'quick',    impact: '“Use Any API Client” bypasses API Access Control, letting a user reach the org from any tool.' },
+  'soap-login-api-auth':     { effort: 'quick',    impact: 'SOAP login() callers without Use Any API Auth stop authenticating in Winter \'27, server to server, with no UI error.' },
   'integration-users':       { effort: 'moderate', impact: 'Over-privileged service accounts are prime targets: one stolen key grants broad, unattended access.' },
   'integration-least-privilege': { effort: 'moderate', impact: 'An integration account keeps whatever it was granted at go-live: long-lived credentials, no interactive user to notice misuse, and frequently outside MFA and IP restrictions. Every permission it is not using is standing privilege waiting on a leaked key.' },
   'content-links':           { effort: 'quick',    impact: 'Public file links without expiry or password leak documents to anyone who finds the URL.' },

--- a/test/unit/checks/impl/ApiClientPermissionCheck.test.ts
+++ b/test/unit/checks/impl/ApiClientPermissionCheck.test.ts
@@ -1,0 +1,88 @@
+import { jest } from '@jest/globals';
+import { ApiClientPermissionCheck } from '../../../../src/checks/impl/ApiClientPermissionCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+import type { CheckResult } from '../../../../src/checks/SecurityCheck.js';
+
+let lastSoql = '';
+
+function makeCtx(rows: unknown[] | Error): AuditContext {
+  return {
+    soql: {
+      query: (jest.fn() as any).mockImplementation((q: string) => {
+        lastSoql = q;
+        return rows instanceof Error ? Promise.reject(rows) : Promise.resolve({ records: rows });
+      }),
+    } as any,
+    tooling: {} as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: {} as any,
+  } as any;
+}
+
+const grant = (Username: string, ownedByProfile = false, profile = 'Sales User', ps = 'API Access') => ({
+  Assignee: { Id: `005${Username}`, Username, Profile: { Name: profile } },
+  PermissionSet: { Name: ps, IsOwnedByProfile: ownedByProfile },
+});
+
+const find = (r: CheckResult, id: string) => r.findings.find((f) => f.id === id);
+
+describe('ApiClientPermissionCheck', () => {
+  const check = new ApiClientPermissionCheck();
+
+  it('passes when nobody holds the permission', async () => {
+    const r = await check.run(makeCtx([]));
+    expect(r.findings).toHaveLength(1);
+    expect(find(r, 'api-client-permission-ok')?.passed).toBe(true);
+  });
+
+  it('reports permission-set grants as MEDIUM and names the granting set', async () => {
+    const r = await check.run(makeCtx([grant('svc@acme.com', false, 'Sales User', 'Integration API')]));
+    const f = find(r, 'api-client-permission-assigned');
+    expect(f?.riskLevel).toBe('MEDIUM');
+    expect(f!.affectedItems![0].note).toBe('via: Integration API');
+  });
+
+  it('escalates to HIGH when any grant comes from a profile', async () => {
+    const r = await check.run(makeCtx([
+      grant('svc@acme.com'),
+      grant('rep@acme.com', true, 'Standard User'),
+    ]));
+    const f = find(r, 'api-client-permission-assigned');
+    expect(f?.riskLevel).toBe('HIGH');
+    expect(f!.affectedItems!.map((i) => i.note)).toContain('via: Profile (Standard User)');
+  });
+
+  it('falls back to "unknown" when a profile grant has no profile name', async () => {
+    const r = await check.run(makeCtx([{
+      Assignee: { Id: '005x', Username: 'x@acme.com' },
+      PermissionSet: { Name: 'PS', IsOwnedByProfile: true },
+    }]));
+    expect(find(r, 'api-client-permission-assigned')!.affectedItems![0].note)
+      .toBe('via: Profile (unknown)');
+  });
+
+  it('is inconclusive when the field does not exist in this edition', async () => {
+    const r = await check.run(makeCtx(new Error('No such column PermissionsUseAnyApiClient')));
+    expect(r.findings).toHaveLength(1);
+    const f = find(r, 'api-client-permission-inconclusive');
+    expect(f?.inconclusive).toBe(true);
+    expect(f?.passed).toBeUndefined();
+  });
+
+  it('excludes inactive and frozen users in the query itself', async () => {
+    await check.run(makeCtx([]));
+    expect(lastSoql).toContain('Assignee.IsActive = true');
+    // Frozen users still hold the grant but cannot use it; counting them would inflate the finding.
+    expect(lastSoql).toContain('IsFrozen = true');
+  });
+
+  it('queries the API Client permission, not the API Auth one it is often confused with', async () => {
+    await check.run(makeCtx([]));
+    expect(lastSoql).toContain('PermissionsUseAnyApiClient');
+    expect(lastSoql).not.toContain('PermissionsUseAnyApiAuth');
+  });
+});

--- a/test/unit/checks/impl/ConnectedAppInactivityCheck.test.ts
+++ b/test/unit/checks/impl/ConnectedAppInactivityCheck.test.ts
@@ -1,0 +1,100 @@
+import { jest } from '@jest/globals';
+import { ConnectedAppInactivityCheck } from '../../../../src/checks/impl/ConnectedAppInactivityCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+import type { CheckResult } from '../../../../src/checks/SecurityCheck.js';
+
+function makeCtx(
+  loginRows: unknown[] | Error,
+  connectedAppNames: string[] | undefined = [],
+): AuditContext {
+  return {
+    soql: {
+      query: (jest.fn() as any).mockImplementation(() =>
+        loginRows instanceof Error
+          ? Promise.reject(loginRows)
+          : Promise.resolve({ records: loginRows }),
+      ),
+    } as any,
+    tooling: {} as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: { connectedAppNames } as any,
+  } as any;
+}
+
+const login = (Application: string, loginCount = 1) => ({ Application, loginCount });
+const find = (r: CheckResult, id: string) => r.findings.find((f) => f.id === id);
+
+describe('ConnectedAppInactivityCheck', () => {
+  const check = new ConnectedAppInactivityCheck();
+
+  it('passes when the org has no connected apps at all', async () => {
+    const r = await check.run(makeCtx([], []));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('connected-app-inactivity-none');
+    expect(r.findings[0].passed).toBe(true);
+  });
+
+  it('treats a missing cache entry the same as no apps', async () => {
+    const r = await check.run(makeCtx([], undefined));
+    expect(r.findings[0].id).toBe('connected-app-inactivity-none');
+  });
+
+  it('is inconclusive when LoginHistory cannot be read', async () => {
+    const r = await check.run(makeCtx(new Error('INSUFFICIENT_ACCESS'), ['Alpha']));
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('connected-app-inactivity-inconclusive');
+    expect(r.findings[0].inconclusive).toBe(true);
+    expect(r.findings[0].passed).toBeUndefined();
+  });
+
+  it('splits apps into active and inactive by recent OAuth logins', async () => {
+    const r = await check.run(makeCtx([login('Alpha')], ['Alpha', 'Beta']));
+    expect(find(r, 'connected-app-active')!.affectedItems!.map((i) => i.label)).toEqual(['Alpha']);
+    expect(find(r, 'connected-app-inactive')!.affectedItems!.map((i) => i.label)).toEqual(['Beta']);
+  });
+
+  it('matches app names case-insensitively against LoginHistory', async () => {
+    const r = await check.run(makeCtx([login('alpha')], ['Alpha']));
+    expect(find(r, 'connected-app-inactive')).toBeUndefined();
+    expect(find(r, 'connected-app-active')).toBeDefined();
+  });
+
+  it('ignores LoginHistory rows with a null Application', async () => {
+    const r = await check.run(makeCtx([{ Application: null, loginCount: 4 }], ['Alpha']));
+    expect(find(r, 'connected-app-inactive')!.affectedItems!.map((i) => i.label)).toEqual(['Alpha']);
+  });
+
+  it('raises inactivity to MEDIUM only past five apps', async () => {
+    const five = ['a', 'b', 'c', 'd', 'e'];
+    expect(find(await check.run(makeCtx([], five)), 'connected-app-inactive')!.riskLevel).toBe('LOW');
+    const six = [...five, 'f'];
+    expect(find(await check.run(makeCtx([], six)), 'connected-app-inactive')!.riskLevel).toBe('MEDIUM');
+  });
+
+  it('reports active apps as INFO, not as a pass', async () => {
+    const r = await check.run(makeCtx([login('Alpha')], ['Alpha']));
+    const f = find(r, 'connected-app-active');
+    expect(f!.riskLevel).toBe('INFO');
+    expect(f!.passed).toBeUndefined();
+  });
+
+  /**
+   * The load-bearing limitation, pinned so it cannot be forgotten. A refresh token is
+   * exchanged for an access token without writing a LoginHistory row of LoginType 'OAuth%',
+   * so an app that still holds a working credential appears here as inactive and merely LOW.
+   * That is the blind spot oauth-token-inventory exists to cover, and this test documents
+   * that this check does not and cannot see it from LoginHistory alone.
+   */
+  it('reports an app as inactive even though it may still hold a live refresh token', async () => {
+    const r = await check.run(makeCtx([], ['Breached Vendor App']));
+    const f = find(r, 'connected-app-inactive');
+    expect(f!.riskLevel).toBe('LOW');
+    expect(f!.affectedItems!.map((i) => i.label)).toEqual(['Breached Vendor App']);
+    // The detail acknowledges the residual credential without measuring it.
+    expect(f!.detail).toContain('still hold valid OAuth credentials');
+  });
+});

--- a/test/unit/checks/impl/ConnectedAppsCheck.test.ts
+++ b/test/unit/checks/impl/ConnectedAppsCheck.test.ts
@@ -1,0 +1,116 @@
+import { jest } from '@jest/globals';
+import { ConnectedAppsCheck } from '../../../../src/checks/impl/ConnectedAppsCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+import type { CheckResult } from '../../../../src/checks/SecurityCheck.js';
+
+function makeCtx(apps: unknown[] | Error): AuditContext {
+  return {
+    soql: {
+      queryAll: (jest.fn() as any).mockImplementation(() =>
+        apps instanceof Error ? Promise.reject(apps) : Promise.resolve(apps),
+      ),
+    } as any,
+    tooling: {} as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: {} as any,
+  } as any;
+}
+
+const app = (
+  Name: string,
+  { restricted = true, SessionTimeout = 15 as number | null } = {},
+) => ({
+  Id: `0CiA${Name}`,
+  Name,
+  OptionsAllowAdminApprovedUsersOnly: restricted,
+  SessionTimeout,
+});
+
+const find = (r: CheckResult, id: string) => r.findings.find((f) => f.id === id);
+
+describe('ConnectedAppsCheck', () => {
+  const check = new ConnectedAppsCheck();
+
+  it('populates connectedAppNames for the checks that depend on it', async () => {
+    const ctx = makeCtx([app('Alpha'), app('Beta')]);
+    await check.run(ctx);
+    // connected-app-inactivity and oauth-token-inventory both read this.
+    expect(ctx.cache.connectedAppNames).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('flags apps that any user may self-authorise', async () => {
+    const r = await check.run(makeCtx([
+      app('Open', { restricted: false }),
+      app('Locked'),
+    ]));
+    const f = find(r, 'unrestricted-connected-apps');
+    expect(f?.riskLevel).toBe('MEDIUM');
+    expect(f!.affectedItems!.map((i) => i.label)).toEqual(['Open']);
+    expect(find(r, 'restricted-connected-apps')).toBeUndefined();
+  });
+
+  it('passes when every app is admin-approved only', async () => {
+    const r = await check.run(makeCtx([app('Locked')]));
+    expect(find(r, 'restricted-connected-apps')?.passed).toBe(true);
+    expect(find(r, 'unrestricted-connected-apps')).toBeUndefined();
+  });
+
+  it('treats an unset or zero session timeout as inheriting the org default', async () => {
+    const r = await check.run(makeCtx([
+      app('Inherits', { SessionTimeout: 0 }),
+      app('Unset', { SessionTimeout: null }),
+    ]));
+    const f = find(r, 'connected-apps-long-session-timeout');
+    expect(f?.riskLevel).toBe('MEDIUM');
+    expect(f!.affectedItems).toHaveLength(2);
+    for (const i of f!.affectedItems!) {
+      expect(i.note).toContain('inherits org default');
+    }
+  });
+
+  it('flags a timeout over the 15 minute SBS-DEP-006 bar and names the value', async () => {
+    const r = await check.run(makeCtx([app('Slow', { SessionTimeout: 120 })]));
+    const f = find(r, 'connected-apps-long-session-timeout');
+    expect(f!.affectedItems![0].note).toContain('120 min');
+  });
+
+  it('accepts exactly 15 minutes as meeting the bar', async () => {
+    const r = await check.run(makeCtx([app('Boundary', { SessionTimeout: 15 })]));
+    expect(find(r, 'connected-apps-long-session-timeout')).toBeUndefined();
+    expect(find(r, 'connected-apps-session-timeout-ok')?.passed).toBe(true);
+  });
+
+  it('reports the app count as a metric', async () => {
+    const r = await check.run(makeCtx([app('A'), app('B'), app('C')]));
+    expect(r.metrics).toEqual({ connectedAppsCount: 3 });
+  });
+
+  /**
+   * An org with no connected apps currently gets a green "All connected apps restrict user
+   * access appropriately", worded as "All 0 connected app(s)". Nothing is unrestricted, so
+   * the verdict is defensible, but the sentence reads as a positive finding about apps that
+   * do not exist. Pinned as current behaviour rather than asserted as correct — see the note
+   * on this test in the commit that added it.
+   */
+  it('emits a passing finding and no timeout finding when the org has no connected apps', async () => {
+    const ctx = makeCtx([]);
+    const r = await check.run(ctx);
+    expect(find(r, 'restricted-connected-apps')?.passed).toBe(true);
+    expect(find(r, 'connected-apps-session-timeout-ok')).toBeUndefined();
+    expect(find(r, 'connected-apps-long-session-timeout')).toBeUndefined();
+    expect(ctx.cache.connectedAppNames).toEqual([]);
+    expect(r.metrics).toEqual({ connectedAppsCount: 0 });
+  });
+
+  it('propagates a query failure rather than reporting a clean org', async () => {
+    // No try/catch here by design: CheckEngine converts a permission error into an
+    // inconclusive finding centrally. What must never happen is a passing finding.
+    await expect(check.run(makeCtx(new Error('INSUFFICIENT_ACCESS')))).rejects.toThrow(
+      'INSUFFICIENT_ACCESS',
+    );
+  });
+});

--- a/test/unit/checks/impl/SoapLoginApiAuthCheck.test.ts
+++ b/test/unit/checks/impl/SoapLoginApiAuthCheck.test.ts
@@ -1,0 +1,172 @@
+import { jest } from '@jest/globals';
+import { SoapLoginApiAuthCheck } from '../../../../src/checks/impl/SoapLoginApiAuthCheck.js';
+import type { AuditContext } from '@cclabsnz/sf-core';
+import type { CheckResult } from '../../../../src/checks/SecurityCheck.js';
+
+type Rows = { records: unknown[] };
+type Step = Rows | Error;
+
+/**
+ * The check issues up to three queries in a fixed order: LoginHistory aggregate,
+ * PermissionSetAssignment, then User. Each test supplies the steps it expects to be
+ * reached, and `calls` lets a test assert the later ones were never issued.
+ */
+function makeCtx(steps: Step[]): AuditContext & { calls: string[] } {
+  const calls: string[] = [];
+  let i = 0;
+  const ctx = {
+    soql: {
+      query: (jest.fn() as any).mockImplementation((q: string) => {
+        calls.push(q);
+        const step = steps[i++];
+        if (step === undefined) throw new Error(`unexpected query #${i}: ${q}`);
+        return step instanceof Error ? Promise.reject(step) : Promise.resolve(step);
+      }),
+    } as any,
+    tooling: {} as any,
+    rest: {} as any,
+    orgInfo: {
+      id: 'o', name: 'n', type: 'DE', isSandbox: false,
+      instance: 'NA1', instanceUrl: 'https://x.my.salesforce.com',
+    },
+    cache: {} as any,
+    calls,
+  } as any;
+  return ctx;
+}
+
+const soapRow = (UserId: string, over = 1, ApiType = 'SOAP Partner', Application = 'DataLoader') =>
+  ({ UserId, Application, ApiType, logins: over });
+
+const holder = (Id: string, Username: string, ownedByProfile = false, profile = 'Integration') => ({
+  Assignee: { Id, Username, Profile: { Name: profile } },
+  PermissionSet: { Name: 'Legacy SOAP Access', IsOwnedByProfile: ownedByProfile },
+});
+
+const user = (Id: string, Username: string, profile = 'Integration') =>
+  ({ Id, Username, Profile: { Name: profile } });
+
+const find = (r: CheckResult, id: string) => r.findings.find((f) => f.id === id);
+
+describe('SoapLoginApiAuthCheck', () => {
+  const check = new SoapLoginApiAuthCheck();
+
+  // spec case 1
+  it('passes when no SOAP logins appear in the window', async () => {
+    const ctx = makeCtx([
+      { records: [{ UserId: '005a', Application: 'Browser', ApiType: null, logins: 9 }] },
+      { records: [] },
+    ]);
+    const r = await check.run(ctx);
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('soap-login-api-auth-ok-no-soap');
+    expect(r.findings[0].passed).toBe(true);
+    expect(ctx.calls).toHaveLength(2); // never resolves usernames
+  });
+
+  // spec case 2
+  it('passes when every SOAP caller already holds the permission', async () => {
+    const r = await check.run(makeCtx([
+      { records: [soapRow('005a')] },
+      { records: [holder('005a', 'svc@acme.com')] },
+      { records: [user('005a', 'svc@acme.com')] },
+    ]));
+    expect(find(r, 'soap-login-api-auth-ok-covered')?.passed).toBe(true);
+    expect(find(r, 'soap-login-api-auth-missing')).toBeUndefined();
+  });
+
+  // spec case 3
+  it('flags only the SOAP caller that lacks the permission', async () => {
+    const r = await check.run(makeCtx([
+      { records: [soapRow('005a'), soapRow('005b')] },
+      { records: [holder('005a', 'covered@acme.com')] },
+      { records: [user('005a', 'covered@acme.com'), user('005b', 'exposed@acme.com')] },
+    ]));
+    const f = find(r, 'soap-login-api-auth-missing');
+    expect(f?.riskLevel).toBe('HIGH');
+    expect(f!.affectedItems).toHaveLength(1);
+    expect(f!.affectedItems![0].label).toBe('exposed@acme.com');
+  });
+
+  // spec case 4
+  it('reports a permission holder who never used SOAP as LOW', async () => {
+    const r = await check.run(makeCtx([
+      { records: [soapRow('005a')] },
+      { records: [holder('005a', 'svc@acme.com'), holder('005z', 'idle@acme.com')] },
+      { records: [user('005a', 'svc@acme.com')] },
+    ]));
+    const f = find(r, 'soap-login-api-auth-unnecessary');
+    expect(f?.riskLevel).toBe('LOW');
+    expect(f!.affectedItems!.map((i) => i.label)).toEqual(['idle@acme.com']);
+    expect(f!.affectedItems![0].note).toContain('Legacy SOAP Access');
+  });
+
+  // spec case 5
+  it('escalates to MEDIUM when the unnecessary grant comes from a profile', async () => {
+    const r = await check.run(makeCtx([
+      { records: [soapRow('005a')] },
+      { records: [holder('005a', 'svc@acme.com'), holder('005z', 'idle@acme.com', true, 'Sales User')] },
+      { records: [user('005a', 'svc@acme.com')] },
+    ]));
+    const f = find(r, 'soap-login-api-auth-unnecessary');
+    expect(f?.riskLevel).toBe('MEDIUM');
+    expect(f!.affectedItems![0].note).toContain('Profile (Sales User)');
+  });
+
+  // spec case 6
+  it('is inconclusive and stops when LoginHistory is unreadable', async () => {
+    const ctx = makeCtx([new Error('INSUFFICIENT_ACCESS')]);
+    const r = await check.run(ctx);
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('soap-login-api-auth-inconclusive-history');
+    expect(r.findings[0].inconclusive).toBe(true);
+    expect(ctx.calls).toHaveLength(1); // never asks about the permission
+  });
+
+  // spec case 7
+  it('is inconclusive with a distinct id when the permission field is absent', async () => {
+    const ctx = makeCtx([
+      { records: [soapRow('005a')] },
+      new Error('No such column PermissionsUseAnyApiAuth'),
+    ]);
+    const r = await check.run(ctx);
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0].id).toBe('soap-login-api-auth-inconclusive-field');
+    expect(r.findings[0].inconclusive).toBe(true);
+    expect(ctx.calls).toHaveLength(2);
+  });
+
+  // spec case 8 — the regression the spec calls out as most likely
+  it('sums logins and lists a user once when they appear under several client identities', async () => {
+    const r = await check.run(makeCtx([
+      { records: [
+        soapRow('005b', 3, 'SOAP Partner', 'DataLoader'),
+        soapRow('005b', 4, 'SOAP Enterprise', 'Custom Client'),
+      ] },
+      { records: [] },
+      { records: [user('005b', 'exposed@acme.com')] },
+    ]));
+    const f = find(r, 'soap-login-api-auth-missing');
+    expect(f!.affectedItems).toHaveLength(1);
+    expect(f!.affectedItems![0].note).toContain('7 SOAP login(s)');
+  });
+
+  it('matches SOAP on Application when ApiType is absent', async () => {
+    const r = await check.run(makeCtx([
+      { records: [{ UserId: '005b', Application: 'SOAP Client', ApiType: null, logins: 2 }] },
+      { records: [] },
+      { records: [user('005b', 'exposed@acme.com')] },
+    ]));
+    expect(find(r, 'soap-login-api-auth-missing')).toBeDefined();
+  });
+
+  it('ignores an inactive SOAP caller that the User query does not return', async () => {
+    const r = await check.run(makeCtx([
+      { records: [soapRow('005dead')] },
+      { records: [] },
+      { records: [] },
+    ]));
+    expect(find(r, 'soap-login-api-auth-missing')).toBeUndefined();
+    expect(find(r, 'soap-login-api-auth-ok-covered')?.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
Two commits: register a check that was written but never ran, then add tests for three untested ones.

## 1. `soap-login-api-auth` was never wired in

`SoapLoginApiAuthCheck` has been sitting in `src/checks/impl/` complete and tsc-clean since Winter '27 planning and **has never run once**. Its design doc explains why: the working tree carried an unfinished `GuestUserVisibilityCheck` touching the same four files, so wiring was deliberately deferred to avoid two half-finished checks in one diff. The other check landed; this one was forgotten. Nothing failed, because an unregistered check is invisible to every test in the suite.

Wired per the spec rather than my own judgement, including where it argued against the obvious choice:

- Registered adjacent to `api-client-permission` so the pair reads together
- Controls `SOC2-CC6.1` + `ISO-A.5.18` (standing-privilege half) and `OWASP-A01` (over-granted case), `accessControl` domain, effort `quick`
- **`SBS-ACS-006` deliberately not reused** — it belongs to Use Any API Client, and reusing it would reproduce in the compliance output the exact conflation this check exists to correct

Ten tests covering the spec's eight named cases plus two more. Case 8 is the one the spec flags as most likely to regress: the LoginHistory aggregate returns one row per `UserId × Application × ApiType`, so a client identifying itself two ways must be neither double-counted nor double-listed.

## 2. Tests for three untested checks

Chosen because they sit on the path the `oauth-token-inventory` work went down, where a defect degrades something else quietly.

| check | why it was picked |
|---|---|
| `connected-apps` | writes `ctx.cache.connectedAppNames`, which two other checks read — a fault there silently changes them, not itself |
| `connected-app-inactivity` | the check whose blind spot motivated `oauth-token-inventory` |
| `api-client-permission` | the permission routinely conflated with the one `soap-login-api-auth` covers |

Two tests are doing more than coverage. `connected-app-inactivity` now asserts that an app dormant for 90 days is still reported LOW even though it may hold a live refresh token — not a defect, but the limit of what LoginHistory can show, pinned so nobody later "fixes" it into false confidence. And `api-client-permission` asserts on the *query text*, that it selects `PermissionsUseAnyApiClient` and not `PermissionsUseAnyApiAuth`, so a copy-paste between the two sibling checks fails a test.

**One behaviour pinned rather than corrected:** an org with zero connected apps gets a passing "All connected apps restrict user access appropriately", worded "All 0 connected app(s)". The verdict is defensible; the sentence reads as a positive finding about apps that do not exist. Changing it is a behaviour change and does not belong in a test-adding commit.

## Numbers

- Checks 91 → **92** (README, `docs/CHECKS.md`)
- Untested checks 36 → **33** of 92 (ROADMAP, ASSURANCE-CASE)
- Suite 1181 → **1206 passing** across 125 suites, build clean