### PR TITLE
chore(release): 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ published note and carries the signed provenance attestation and CycloneDX SBOM 
 
 Merged to `main`, not yet released.
 
+## [v1.12.0](https://github.com/cclabsnz/sf-audit-plugin/releases/tag/v1.12.0) — 2026-09-07
+
+A check that shipped in the source but never ran, now registered, plus tests for three more.
+
+### Added
+
+- **`soap-login-api-auth`** — flags accounts that authenticate with SOAP API `login()` but do not
+  hold the "Use Any API Auth" permission that Winter '27 requires, and separately flags holders
+  that no longer need it.
+
+  The check class has been present and compiling since Winter '27 planning and **had never run**:
+  its registry, compliance, `CheckMeta` and test wiring were deferred behind another unfinished
+  check and then forgotten. An unregistered check is invisible to the whole suite, so nothing
+  failed. It runs now.
+
+  Worth stating because published coverage of this change routinely gets it wrong: "Use Any API
+  Auth" is **not** the same permission as "Use Any API Client", which the separate
+  `api-client-permission` check covers. Granting the wrong one leaves the breakage in place while
+  feeling remediated. The compliance mapping deliberately does not reuse the Use Any API Client
+  control, for the same reason.
+
+  Both halves matter. The missing-permission half is an availability finding: the failure lands at
+  authentication, server to server, with no error anywhere in the Salesforce UI. The
+  already-granted half is a security finding, because granting broadly at profile level is the
+  common response to this change and converts a breakage problem into a standing-privilege one.
+
+### Changed
+
+- Check count is now **92**.
+
+### Internal
+
+- Unit tests added for `connected-apps`, `connected-app-inactivity` and `api-client-permission`.
+  Untested checks drop from 36 to 33 of 92. The `connected-apps` tests pin the
+  `connectedAppNames` cache write that two other checks read, and the `api-client-permission`
+  tests assert on the query text so a copy-paste between the two easily-confused API permissions
+  fails a test.
+
 ## [v1.11.0](https://github.com/cclabsnz/sf-audit-plugin/releases/tag/v1.11.0) — 2026-09-07
 
 One new check, closing a blind spot that the SaaS token-theft campaigns of the last year

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cclabsnz/sf-audit",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Read-only Salesforce security audit for the sf CLI: 88 checks, attack-chain correlation, A-F risk grading, and compliance mapping to OWASP, SOC 2, ISO 27001, NZISM and more.",
   "keywords": [
     "salesforce",


### PR DESCRIPTION
Version bump and changelog for **1.12.0**, per `docs/RELEASE.md` steps 1–2.

Minor rather than patch: check count moves to 92 and `soap-login-api-auth` produces findings an org did not see before, so a CI gate can change result without the org changing.

Contents merged in #105. No behaviour change to existing checks.

**Timing.** The new check reports readiness for a Winter '27 enforcement. Its value is highest before an org takes the release; afterwards it can only explain a broken integration rather than prevent one.

### Gates (step 3)

| | |
|---|---|
| `pnpm install --frozen-lockfile` | ok |
| `pnpm run build` | clean tsc |
| `pnpm test` | 1206 passing / 125 suites |
| `pnpm audit --prod --audit-level high` | no known vulnerabilities |

After merge: tag `v1.12.0` and publish the release, triggering `publish.yml` (build + test, `npm publish --provenance --access public`, CycloneDX SBOM attached).