### PR TITLE
docs(trust): answer the Socket dependency alerts, and record the jszip MIT election

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,11 @@ jobs:
           # redistribute in a permissively-licensed (Apache-2.0) CLI. Applies to
           # PR-added deps only; tune the list as needed.
           deny-licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later
+          # Recorded exception, so the policy above stays true to what actually ships.
+          # jszip declares "(MIT OR GPL-3.0-or-later)" and reaches us transitively through
+          # @salesforce/core -> @jsforce/jsforce-node. A disjunction is the publisher offering
+          # a choice: this project takes the MIT branch, which is why a GPL-denying policy and
+          # a shipped jszip are not in conflict. Scanners that surface only the copyleft half
+          # (Socket's "Copyleft License" alert does) are reading the same manifest, not
+          # reporting a second licence. See docs/TRUST.md.
+          allow-dependencies-licenses: pkg:npm/jszip

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -14,13 +14,13 @@ Because this tool authenticates against production orgs, "is it safe to run?" de
   npm audit signatures   # reports "verified attestations" for @cclabsnz/sf-audit
   ```
 
-- **Independent scans on every change.** Two static-analysis engines — [CodeQL](https://github.com/cclabsnz/sf-audit-plugin/security/code-scanning) (`security-extended`, of both the source **and** the CI workflows) and [Semgrep](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/semgrep.yml) (OWASP Top 10 + security-audit rulesets) — an [OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/cclabsnz/sf-audit-plugin) supply-chain review, a PR **dependency-review** gate (vulnerabilities **and** a copyleft-license policy), and a `pnpm audit` gate — plus Dependabot, and GitHub secret scanning with push protection. All GitHub Actions are pinned to commit SHAs. Each release ships a CycloneDX **SBOM**.
-- **Regulated-environment readiness.** The above give reviewers a paper trail for procurement: SBOM per release, an enforced dependency **license policy**, signed provenance, and independent SAST/supply-chain scans.
+- **Independent scans on every change.** Two static-analysis engines — [CodeQL](https://github.com/cclabsnz/sf-audit-plugin/security/code-scanning) (`security-extended`, of both the source **and** the CI workflows) and [Semgrep](https://github.com/cclabsnz/sf-audit-plugin/actions/workflows/semgrep.yml) (OWASP Top 10 + security-audit rulesets) — an [OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/cclabsnz/sf-audit-plugin) supply-chain review, a PR **dependency-review** gate (vulnerabilities, plus a copyleft-license policy over the dependencies a PR adds), and a `pnpm audit` gate — plus Dependabot, and GitHub secret scanning with push protection. All GitHub Actions are pinned to commit SHAs. Each release ships a CycloneDX **SBOM**.
+- **Regulated-environment readiness.** The above give reviewers a paper trail for procurement: SBOM per release, a dependency **license policy** enforced on every PR that adds a dependency, signed provenance, and independent SAST/supply-chain scans. What the policy does *not* do is re-litigate the tree that arrives with the Salesforce CLI SDK; [what third-party scanners flag in that tree](#alerts-on-the-dependency-tree) is set out below rather than left to the reader.
 - **Least privilege & disclosure.** See [PERMISSIONS.md](../PERMISSIONS.md) for the minimal access it needs and [SECURITY.md](../SECURITY.md) for private vulnerability reporting.
 
 ## What third-party scanners flag, and why
 
-[Socket](https://socket.dev/npm/package/@cclabsnz/sf-audit) raises two **supply-chain risk** alerts against this package. Neither is a vulnerability — both are behavioural heuristics — and rather than suppress them quietly, here is exactly what triggers each and how you can confirm it. The triage is committed as [`socket.yml`](../socket.yml).
+[Socket](https://socket.dev/npm/package/@cclabsnz/sf-audit) raises two **supply-chain risk** alerts against this package itself. Neither is a vulnerability — both are behavioural heuristics — and rather than suppress them quietly, here is exactly what triggers each and how you can confirm it. The triage is committed as [`socket.yml`](../socket.yml). Socket's separate **Dependencies** tab is covered [further down](#alerts-on-the-dependency-tree).
 
 | Alert | What triggers it | Why it is expected |
 | --- | --- | --- |
@@ -34,7 +34,7 @@ npm pack @cclabsnz/sf-audit && tar xzf cclabsnz-sf-audit-*.tgz
 grep -rhoE 'https?://[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}[^"'"'"'`,;) ]*' package/lib | sort -u
 ```
 
-As of v1.11.0 that prints twelve results. Nine are the standards-body citations rendered as `<a href>` in compliance findings:
+As of v1.12.0 that prints twelve results. Nine are the standards-body citations rendered as `<a href>` in compliance findings:
 
 ```
 https://docs.securitybenchmark.org/controls-at-a-glance.html
@@ -57,3 +57,28 @@ https://softwareinsights.dev                    # further-reading pointer in CLI
 ```
 
 No CDN, telemetry, or analytics endpoints — and the network-egress invariant above fails the build if one is ever added.
+
+## Alerts on the dependency tree
+
+Socket's **Dependencies** tab is a separate list from the two alerts above, and it is longer: twenty alert types across the roughly 260 packages Socket resolves. That number invites a wrong conclusion, so here is the structural fact first.
+
+This package declares **six** direct dependencies — `@cclabsnz/sf-core`, `@oclif/core`, `@salesforce/core`, `@salesforce/sf-plugins-core`, `chart.js` and `zod`. Every flagged package is something one of those brings with it, and all but one of them sit in the tree that any `sf` CLI plugin inherits: `@salesforce/core` (and through it `@jsforce/jsforce-node`, `faye`, `jszip`, `xml2js`, `memfs`, `pino`), `@oclif/core`, and `@salesforce/sf-plugins-core`. `chart.js` and `zod` are effectively clean. **There is no dependency this project could drop to move these numbers**, which is worth saying plainly rather than implying the tree was chosen carelessly. `pnpm audit --prod` reports no known vulnerabilities, and the CI gate above fails the build if that changes.
+
+Five alerts are worth an actual answer rather than a count:
+
+| Alert | Package | What is actually true |
+| --- | --- | --- |
+| **Copyleft License** | `jszip@3.10.1`, via `@salesforce/core` → `@jsforce/jsforce-node` | jszip declares `(MIT OR GPL-3.0-or-later)`. A disjunction is the publisher offering a choice, and this project takes the MIT branch — recorded as an explicit exception in the dependency-review policy in `.github/workflows/ci.yml`, not left implicit. Socket reports the copyleft half of that disjunction; it has not found a second licence. |
+| **Non-permissive License** | `@cclabsnz/sf-core` — OFL-1.1 | This is the font licence, not a code licence. sf-core ships `src/assets/fonts/OFL.txt` beside the four embedded webfont families, because OFL §1 requires the licence text to travel with redistributed fonts. The code is Apache-2.0. This is the same bundling that makes generated reports self-contained and CDN-free. Attribution is in [`NOTICE.md`](https://github.com/cclabsnz/sf-core/blob/main/src/assets/fonts/NOTICE.md). |
+| **Potential vulnerability** | `@jsonjoy.com/codegen@1.0.0`, via `memfs` ← `@salesforce/core` | Socket's note is that `compile(js)` calls `eval(js)`. It is graded medium, is flagged as pending further analysis, and has no CVE. It is a code-generation library doing code generation. |
+| **AI-detected potential security risk** | `xml2js` (jsforce), `thread-stream` (pino), `powershell-utils` (`@oclif/core` → `wsl-utils`) | Heuristic findings on three long-standing packages in the Salesforce and oclif trees. `powershell-utils` is oclif's WSL detection path on Windows. |
+| **Shell access** | `@jsforce/jsforce-node`, `@salesforce/core`, `powershell-utils`, `wsl-utils` | The SDK and the CLI framework can reach the shell; this plugin does not. Socket's own capability record for `@cclabsnz/sf-audit` reads `shell: false`, `eval: false`, `env: false`, `net: false` — the one network caller is `@cclabsnz/sf-core`, and its only destination is the org you authenticated against (the EventLogFile download in `RestClientImpl`). |
+
+The remaining fifteen are volume rather than signal: 56 packages not published in five years (`lodash.isstring`, `safe-buffer`, `wordwrap`, `xmlbuilder` and similar leaves), plus counts for URL strings, environment-variable access, filesystem access and `eval` across the tree. Four "possible typosquat" hits — `ansis`, `camel-case`, `fast-string-width`, `fast-wrap-ansi` — are legitimate oclif dependencies whose names resemble more popular ones.
+
+Confirm the attribution yourself, without taking any of the above on trust:
+
+```bash
+npm ls jszip @jsonjoy.com/codegen xml2js   # or: pnpm why jszip
+npm view jszip license                     # (MIT OR GPL-3.0-or-later)
+```

--- a/socket.yml
+++ b/socket.yml
@@ -3,6 +3,16 @@
 # Triage for the supply-chain alerts Socket raises against these packages. Both remaining
 # alerts are inherent to what a local-first CLI security auditor does; neither is a
 # vulnerability. They are acknowledged here rather than silently ignored.
+#
+# Socket's Dependencies tab is a separate, longer list, and nothing here suppresses any of
+# it — deliberately. Those alerts sit on the tree that arrives with the Salesforce CLI SDK
+# (@salesforce/core, @jsforce/jsforce-node, @oclif/core, @salesforce/sf-plugins-core), which
+# this package cannot choose, and a blanket rule here would also hide the next genuine one.
+# The five that warrant an answer — jszip's (MIT OR GPL-3.0-or-later) dual licence, the
+# OFL-1.1 font attribution in @cclabsnz/sf-core, @jsonjoy.com/codegen, the AI-heuristic hits,
+# and shell access in the SDK — are answered in docs/TRUST.md under "Alerts on the
+# dependency tree". The jszip MIT election is also recorded in the dependency-review policy
+# in .github/workflows/ci.yml, so the licence gate and the shipped tree agree.
 version: 2
 
 projectIgnorePaths:


### PR DESCRIPTION
Socket's **Dependencies** tab raises twenty alert types across roughly 260 resolved packages. `docs/TRUST.md` covered the two alerts against this package and said nothing about that tab, which is the longer list and the one a procurement reviewer lands on first. Unanswered, the count reads as an unexamined tree.

## What this changes

**`.github/workflows/ci.yml`** — the one real defect. The dependency-review policy denies `GPL-3.0-or-later`, and `jszip` has been in the shipped tree the whole time under exactly that SPDX id, via `@salesforce/core` → `@jsforce/jsforce-node`. Nothing was failing, because the gate only inspects dependencies a PR adds, but the policy and the tree disagreed on paper while Socket's public page showed the Copyleft License alert that makes the disagreement visible.

jszip declares `(MIT OR GPL-3.0-or-later)`. A disjunction is the publisher offering a choice; this project takes the MIT branch. That election was implicit, which is the actual problem: an unwritten choice is indistinguishable from an oversight to whoever is reading the manifest. Now recorded as `allow-dependencies-licenses: pkg:npm/jszip`.

**`docs/TRUST.md`** — new "Alerts on the dependency tree" section. Six direct dependencies are declared here; every flagged package is inherited from the tree any `sf` CLI plugin takes on (`@salesforce/core` and through it jsforce, faye, jszip, xml2js, memfs, pino, plus `@oclif/core` and `@salesforce/sf-plugins-core`). `chart.js` and `zod` are clean. There is nothing to drop, stated plainly rather than left to inference. The five alerts that deserve an answer get one, with attribution a reader can reproduce in two commands.

Two claims elsewhere were broader than the mechanism behind them. "A copyleft-license policy" and "an enforced dependency license policy" both described a gate that only sees PR-added dependencies; they now say so. A claim a reviewer can falsify by reading the workflow costs more than it was worth. The URL-count line moves to v1.12.0, re-run rather than assumed: still twelve, unchanged.

**`socket.yml`** — records why the dependency alerts are *not* suppressed. Silencing `copyleftLicense` and `nonpermissiveLicense` would clear the public page and also hide the next dependency that genuinely is either one.

## Verification

- `npm run build` clean; `npm test` green, 1206 passing across 125 suites
- `pnpm audit --prod` reports no known vulnerabilities
- `allow-dependencies-licenses` is supported at the pinned SHA (`cc4f6536` is release 3.1.5), so no action bump is needed
- The new input is not exercised until a PR touches dependencies, most likely the next Dependabot one

No source or check behaviour changes; docs, CI policy and triage only.